### PR TITLE
Skip actions enablement on org lvl, if enabledRepo is not set in CRD

### DIFF
--- a/internal/controller/organization/organization.go
+++ b/internal/controller/organization/organization.go
@@ -219,11 +219,12 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	if err != nil {
 		return managed.ExternalUpdate{}, err
 	}
-
-	for _, missingRepo := range missingReposIds {
-		_, err := gh.Actions.AddEnabledReposInOrg(ctx, name, missingRepo)
-		if err != nil {
-			return managed.ExternalUpdate{}, err
+	if cr.Spec.ForProvider.Actions.EnabledRepos != nil {
+		for _, missingRepo := range missingReposIds {
+			_, err := gh.Actions.AddEnabledReposInOrg(ctx, name, missingRepo)
+			if err != nil {
+				return managed.ExternalUpdate{}, err
+			}
 		}
 	}
 
@@ -233,10 +234,12 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	// Disable actions for missing repositories
-	for _, toDeleteRepo := range toDeleteReposIds {
-		_, err := gh.Actions.RemoveEnabledRepoInOrg(ctx, name, toDeleteRepo)
-		if err != nil {
-			return managed.ExternalUpdate{}, err
+	if cr.Spec.ForProvider.Actions.EnabledRepos != nil {
+		for _, toDeleteRepo := range toDeleteReposIds {
+			_, err := gh.Actions.RemoveEnabledRepoInOrg(ctx, name, toDeleteRepo)
+			if err != nil {
+				return managed.ExternalUpdate{}, err
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Small fix that will change logic for actions, to skip enable or disable repos on org level if crd has not defined enabledRepos at all

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
