### PR TITLE
Use SHA-1 instead of MD5 when hashing the webhook URL in the repo connection secret

### DIFF
--- a/internal/controller/repository/repository.go
+++ b/internal/controller/repository/repository.go
@@ -341,7 +341,7 @@ func (c *external) getRepoWebhookSecretFromState(ctx context.Context, cr *v1alph
 		return "", errors.New("`spec.writeConnectionSecretToReference` is not set")
 	}
 
-	secretKey := util.GenerateMD5Hash(webhook.Config.GetURL())
+	secretKey := util.GenerateSHA1Hash(webhook.Config.GetURL())
 	secretName := cr.Spec.WriteConnectionSecretToReference.Name
 	secretNamespace := cr.Spec.WriteConnectionSecretToReference.Namespace
 	nn := types.NamespacedName{
@@ -885,7 +885,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 				return managed.ExternalCreation{}, err
 			}
 			if hookConfig.Config.Secret != nil {
-				err = c.updateConnectionSecretEntry(ctx, cr, util.GenerateMD5Hash(hook.Url), webhookSecretState{
+				err = c.updateConnectionSecretEntry(ctx, cr, util.GenerateSHA1Hash(hook.Url), webhookSecretState{
 					WebhookUrl:    *hookConfig.Config.URL,
 					WebhookSecret: *hookConfig.Config.Secret,
 				})
@@ -1026,7 +1026,7 @@ func updateRepoWebhooks(c *external, ctx context.Context, cr *v1alpha1.Repositor
 			return err
 		}
 		if hook.Secret != nil {
-			err = c.deleteConnectionSecretEntry(ctx, cr, util.GenerateMD5Hash(hook.Url))
+			err = c.deleteConnectionSecretEntry(ctx, cr, util.GenerateSHA1Hash(hook.Url))
 			if err != nil {
 				return err
 			}
@@ -1040,7 +1040,7 @@ func updateRepoWebhooks(c *external, ctx context.Context, cr *v1alpha1.Repositor
 			return err
 		}
 		if hookConfig.Config.Secret != nil {
-			err = c.updateConnectionSecretEntry(ctx, cr, util.GenerateMD5Hash(hook.Url), webhookSecretState{
+			err = c.updateConnectionSecretEntry(ctx, cr, util.GenerateSHA1Hash(hook.Url), webhookSecretState{
 				WebhookUrl:    *hookConfig.Config.URL,
 				WebhookSecret: *hookConfig.Config.Secret,
 			})
@@ -1062,14 +1062,14 @@ func updateRepoWebhooks(c *external, ctx context.Context, cr *v1alpha1.Repositor
 		}
 
 		// Clear connection secret entry first, if it exists
-		err = c.deleteConnectionSecretEntry(ctx, cr, util.GenerateMD5Hash(*hookConfig.Config.URL))
+		err = c.deleteConnectionSecretEntry(ctx, cr, util.GenerateSHA1Hash(*hookConfig.Config.URL))
 		if err != nil {
 			return err
 		}
 
 		// Add updated connection secret entry, if needed
 		if hookConfig.Config.Secret != nil {
-			err = c.updateConnectionSecretEntry(ctx, cr, util.GenerateMD5Hash(hook.Url), webhookSecretState{
+			err = c.updateConnectionSecretEntry(ctx, cr, util.GenerateSHA1Hash(hook.Url), webhookSecretState{
 				WebhookUrl:    *hookConfig.Config.URL,
 				WebhookSecret: *hookConfig.Config.Secret,
 			})

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -18,7 +18,7 @@ package util
 
 import (
 	// nolint:gosec
-	"crypto/md5"
+	"crypto/sha1"
 	"encoding/hex"
 	"reflect"
 	"sort"
@@ -280,11 +280,11 @@ func Int64DerefToPointer(ptr *int64, def int64) *int64 {
 	return &i
 }
 
-// GenerateMD5Hash hashes a string to MD5
-func GenerateMD5Hash(s string) string {
-	// Create an MD5 hash of the string
+// GenerateSHA1Hash hashes a string to SHA-1
+func GenerateSHA1Hash(s string) string {
+	// Create a SHA-1 hash of the string
 	// nolint:gosec
-	hash := md5.New()
+	hash := sha1.New()
 	hash.Write([]byte(s))
 	hashedBytes := hash.Sum(nil)
 


### PR DESCRIPTION
### Description of your changes

When Helm is used to deploy `Repository` resources with webhooks that have `secrets` enabled, Helm needs to hash the webhook URL into a key within the Kubernetes secret that contains the webhook secrets. However, Helm only supports `SHA-1` or higher for hashing. Similarly, `provider-github` hashes repo webhook URLs when storing the current state of the repository, so it is advisable to use SHA-1. This consistency aids in troubleshooting when comparing the Kubernetes secret containing the `Repository` webhook secrets with the Kubernetes `Repository` connection secret.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
