### PR TITLE
fix reconciliation loop for repository collaborators, GitHub users are case-insensitive

### DIFF
--- a/internal/controller/repository/repository.go
+++ b/internal/controller/repository/repository.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -267,7 +268,8 @@ func getUserPermissionMapFromCr(users []v1alpha1.RepositoryUser) map[string]stri
 	crMToPermission := make(map[string]string, len(users))
 
 	for _, user := range users {
-		crMToPermission[user.User] = user.Role
+		username := strings.ToLower(user.User)
+		crMToPermission[username] = user.Role
 	}
 
 	return crMToPermission
@@ -541,11 +543,12 @@ func getRepoUsersWithPermissions(ctx context.Context, gh *ghclient.Client, org, 
 		}
 
 		for _, m := range users {
-			uToPermission[*m.Login] = "pull"
+			username := strings.ToLower(*m.Login)
+			uToPermission[username] = "pull"
 
 			for _, p := range permissionsOrdered {
 				if m.Permissions[p] {
-					uToPermission[*m.Login] = p
+					uToPermission[username] = p
 					break
 				}
 			}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Resolves issues in the reconciliation loop caused by discrepancies in case sensitivity between the repository collaborator's GitHub username and the actual GitHub username

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

The change was tested E2E manually.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
