### PR TITLE
Replace deprecated actions/upload-artifact@v3 in favor of actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
           BUILD_ARGS: "--load"
 
       - name: Publish Artifacts to GitHub
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: output
           path: _output/**


### PR DESCRIPTION
Migrate from `actions/upload-artifact@v3` to `actions/upload-artifact@v4` in response to GitHub's announcement of v3 deprecation: https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/#artifacts-v3-brownouts
