### PR TITLE
Skip branch protection rules targeting missing branches

### DIFF
--- a/internal/controller/repository/repository.go
+++ b/internal/controller/repository/repository.go
@@ -32,6 +32,7 @@ import (
 	pointer "k8s.io/utils/ptr"
 
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -208,11 +209,13 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	if cr.Spec.ForProvider.BranchProtectionRules != nil {
-		protectedBranches, err := listProtectedBranches(ctx, c.github, cr.Spec.ForProvider.Org, name)
+		protectedBranches, existingBranches, err := listBranches(ctx, c.github, cr.Spec.ForProvider.Org, name)
 		if err != nil {
 			return managed.ExternalObservation{}, err
 		}
 		crBPRToConfig := getBPRMapFromCr(cr.Spec.ForProvider.BranchProtectionRules)
+		skipped := filterMissingBranchProtectionRules(crBPRToConfig, existingBranches)
+		setBranchProtectionPartialCondition(ctx, cr, skipped)
 		ghBPRToConfig, err := getBPRWithConfig(ctx, c.github, cr.Spec.ForProvider.Org, name, protectedBranches)
 		if err != nil {
 			return managed.ExternalObservation{}, err
@@ -582,11 +585,14 @@ func getRepoUsersWithPermissions(ctx context.Context, gh *ghclient.RateLimitClie
 	return uToPermission, nil
 }
 
-// listProtectedBranches retrieves all protected branches for a given GitHub repository.
-// It uses pagination to handle large numbers of branches, fetching 100 branches per API call.
-func listProtectedBranches(ctx context.Context, gh *ghclient.RateLimitClient, org, repoName string) ([]*github.Branch, error) {
+// listBranches lists all branches for a GitHub repository in a single
+// paginated call and returns both the protected subset and the set of all
+// branch names. Callers use the protected subset to fetch existing
+// protection configs, and the name set to filter out CR rules that point
+// at branches the repo doesn't have — preventing wasted 404 calls to
+// UpdateBranchProtection.
+func listBranches(ctx context.Context, gh *ghclient.RateLimitClient, org, repoName string) ([]*github.Branch, map[string]bool, error) {
 	opts := &github.BranchListOptions{
-		Protected:   github.Bool(true),
 		ListOptions: github.ListOptions{PerPage: 100},
 	}
 	var allBranches []*github.Branch
@@ -594,7 +600,7 @@ func listProtectedBranches(ctx context.Context, gh *ghclient.RateLimitClient, or
 	for {
 		branches, resp, err := gh.Repositories.ListBranches(ctx, org, repoName, opts)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		allBranches = append(allBranches, branches...)
 
@@ -604,7 +610,63 @@ func listProtectedBranches(ctx context.Context, gh *ghclient.RateLimitClient, or
 		opts.Page = resp.NextPage
 	}
 
-	return allBranches, nil
+	existing := make(map[string]bool, len(allBranches))
+	var protected []*github.Branch
+	for _, b := range allBranches {
+		existing[b.GetName()] = true
+		if b.GetProtected() {
+			protected = append(protected, b)
+		}
+	}
+	return protected, existing, nil
+}
+
+// filterMissingBranchProtectionRules removes entries from rules whose
+// branch is not present in existing. Returns the sorted list of skipped
+// branch names so callers can log and emit an Event. Mutates rules.
+func filterMissingBranchProtectionRules(rules map[string]v1alpha1.BranchProtectionRule, existing map[string]bool) []string {
+	var skipped []string
+	for branch := range rules {
+		if !existing[branch] {
+			skipped = append(skipped, branch)
+			delete(rules, branch)
+		}
+	}
+	sort.Strings(skipped)
+	return skipped
+}
+
+// Condition surfaced on the Repository CR when one or more declared
+// branch protection rules can't be applied because their target branch
+// doesn't exist in the repo. Conditions are quieter than Events:
+// Crossplane only writes a status update when the condition's
+// (Status, Reason, Message) actually changes, so steady-state and
+// controller restarts don't generate noise.
+const (
+	typeBranchProtectionPartial xpv1.ConditionType   = "BranchProtectionPartial"
+	reasonBranchesMissing       xpv1.ConditionReason = "BranchesMissing"
+	reasonAllBranchesPresent    xpv1.ConditionReason = "AllBranchesPresent"
+)
+
+// setBranchProtectionPartialCondition reflects the current skipped set
+// on the CR's status. Idempotent — SetConditions ignores writes whose
+// (Status, Reason, Message) match the existing condition.
+func setBranchProtectionPartialCondition(ctx context.Context, cr *v1alpha1.Repository, skipped []string) {
+	c := xpv1.Condition{
+		Type:               typeBranchProtectionPartial,
+		LastTransitionTime: metav1.Now(),
+	}
+	if len(skipped) == 0 {
+		c.Status = corev1.ConditionFalse
+		c.Reason = reasonAllBranchesPresent
+	} else {
+		c.Status = corev1.ConditionTrue
+		c.Reason = reasonBranchesMissing
+		c.Message = fmt.Sprintf("branches do not exist in repo: %s", strings.Join(skipped, ", "))
+		ctrl.LoggerFrom(ctx).Info("skipping branch protection rules for missing branches",
+			"repository", meta.GetExternalName(cr), "branches", skipped)
+	}
+	cr.SetConditions(c)
 }
 
 // getBPRMapFromCr generates a map from a slice of BranchProtectionRules. Each rule is first processed:
@@ -919,8 +981,14 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	if cr.Spec.ForProvider.BranchProtectionRules != nil {
+		_, existingBranches, err := listBranches(ctx, c.github, cr.Spec.ForProvider.Org, name)
+		if err != nil {
+			return managed.ExternalCreation{}, err
+		}
 		// getBPRMapFromCr() provides defaults for optional *bool fields
 		rulesMap := getBPRMapFromCr(cr.Spec.ForProvider.BranchProtectionRules)
+		skipped := filterMissingBranchProtectionRules(rulesMap, existingBranches)
+		setBranchProtectionPartialCondition(ctx, cr, skipped)
 		for key := range rulesMap {
 			// avoid "G601: Implicit memory aliasing in for loop"
 			rule := rulesMap[key]
@@ -1200,11 +1268,13 @@ func editProtectedBranch(ctx context.Context, rule *v1alpha1.BranchProtectionRul
 // It performs necessary additions, updates, or deletions based on the difference between
 // the actual state on GitHub and the desired state in the resource object.
 func updateProtectedBranches(ctx context.Context, cr *v1alpha1.Repository, gh *ghclient.RateLimitClient, repoName string) error {
-	protectedBranches, err := listProtectedBranches(ctx, gh, cr.Spec.ForProvider.Org, repoName)
+	protectedBranches, existingBranches, err := listBranches(ctx, gh, cr.Spec.ForProvider.Org, repoName)
 	if err != nil {
 		return err
 	}
 	crBPRToConfig := getBPRMapFromCr(cr.Spec.ForProvider.BranchProtectionRules)
+	skipped := filterMissingBranchProtectionRules(crBPRToConfig, existingBranches)
+	setBranchProtectionPartialCondition(ctx, cr, skipped)
 	ghBPRToConfig, err := getBPRWithConfig(ctx, gh, cr.Spec.ForProvider.Org, repoName, protectedBranches)
 	if err != nil {
 		return err

--- a/internal/controller/repository/repository_test.go
+++ b/internal/controller/repository/repository_test.go
@@ -27,11 +27,13 @@ import (
 	ghclient "github.com/crossplane/provider-github/internal/clients"
 	"github.com/crossplane/provider-github/internal/clients/fake"
 
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-github/v62/github"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // Unlike many Kubernetes projects Crossplane does not use third party testing
@@ -636,5 +638,144 @@ func TestObserve(t *testing.T) {
 				t.Errorf("\n%s\ne.Observe(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
+	}
+}
+
+// filterMissingBranchProtectionRules is what stops the controller from
+// calling UpdateBranchProtection on branches that don't exist. Asserts:
+// rules for missing branches are removed from the map, rules for existing
+// branches are kept untouched, and the skipped list is returned sorted so
+// the condition message is stable across reconciles.
+func TestFilterMissingBranchProtectionRules(t *testing.T) {
+	cases := map[string]struct {
+		rules       map[string]v1alpha1.BranchProtectionRule
+		existing    map[string]bool
+		wantRules   map[string]v1alpha1.BranchProtectionRule
+		wantSkipped []string
+	}{
+		"AllBranchesExist_NothingFiltered": {
+			rules: map[string]v1alpha1.BranchProtectionRule{
+				"main":    {Branch: "main"},
+				"develop": {Branch: "develop"},
+			},
+			existing: map[string]bool{"main": true, "develop": true},
+			wantRules: map[string]v1alpha1.BranchProtectionRule{
+				"main":    {Branch: "main"},
+				"develop": {Branch: "develop"},
+			},
+			wantSkipped: nil,
+		},
+		"SomeMissing_FilteredAndReturnedSorted": {
+			rules: map[string]v1alpha1.BranchProtectionRule{
+				"main":    {Branch: "main"},
+				"release": {Branch: "release"},
+				"develop": {Branch: "develop"},
+			},
+			existing: map[string]bool{"main": true},
+			wantRules: map[string]v1alpha1.BranchProtectionRule{
+				"main": {Branch: "main"},
+			},
+			wantSkipped: []string{"develop", "release"},
+		},
+		"AllMissing_MapEmptied": {
+			rules: map[string]v1alpha1.BranchProtectionRule{
+				"develop": {Branch: "develop"},
+				"release": {Branch: "release"},
+			},
+			existing:    map[string]bool{},
+			wantRules:   map[string]v1alpha1.BranchProtectionRule{},
+			wantSkipped: []string{"develop", "release"},
+		},
+		"EmptyInput_NoChange": {
+			rules:       map[string]v1alpha1.BranchProtectionRule{},
+			existing:    map[string]bool{"main": true},
+			wantRules:   map[string]v1alpha1.BranchProtectionRule{},
+			wantSkipped: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			gotSkipped := filterMissingBranchProtectionRules(tc.rules, tc.existing)
+			if diff := cmp.Diff(tc.wantSkipped, gotSkipped); diff != "" {
+				t.Errorf("skipped: -want, +got:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantRules, tc.rules); diff != "" {
+				t.Errorf("rules after filter: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+// setBranchProtectionPartialCondition is the operator-facing signal for
+// "some desired BPRs can't apply right now". Asserts: non-empty skipped →
+// status True with sorted branch names in the message; empty skipped →
+// status False (resource is fully converged on this dimension). Crossplane's
+// SetConditions dedupes identical writes, so steady-state reconciles don't
+// thrash the status — this test pins the (Status, Reason, Message) shape
+// that dedup depends on.
+func TestSetBranchProtectionPartialCondition(t *testing.T) {
+	cases := map[string]struct {
+		skipped     []string
+		wantStatus  corev1.ConditionStatus
+		wantReason  xpv1.ConditionReason
+		wantInMsg   []string
+		wantMsgZero bool
+	}{
+		"Empty_FalseAndAllBranchesPresentReason": {
+			skipped:     nil,
+			wantStatus:  corev1.ConditionFalse,
+			wantReason:  "AllBranchesPresent",
+			wantMsgZero: true,
+		},
+		"NonEmpty_TrueAndNamesBranchesInMessage": {
+			skipped:    []string{"develop", "release"},
+			wantStatus: corev1.ConditionTrue,
+			wantReason: "BranchesMissing",
+			wantInMsg:  []string{"develop", "release"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			cr := &v1alpha1.Repository{}
+			setBranchProtectionPartialCondition(context.Background(), cr, tc.skipped)
+
+			c := cr.GetCondition("BranchProtectionPartial")
+			if c.Status != tc.wantStatus {
+				t.Errorf("Status = %q, want %q", c.Status, tc.wantStatus)
+			}
+			if c.Reason != tc.wantReason {
+				t.Errorf("Reason = %q, want %q", c.Reason, tc.wantReason)
+			}
+			if tc.wantMsgZero && c.Message != "" {
+				t.Errorf("Message = %q, want empty", c.Message)
+			}
+			for _, want := range tc.wantInMsg {
+				if !strings.Contains(c.Message, want) {
+					t.Errorf("Message %q missing %q", c.Message, want)
+				}
+			}
+		})
+	}
+}
+
+// SetConditions on identical content is idempotent. Calling
+// setBranchProtectionPartialCondition twice with the same skipped set
+// must not append a duplicate to status.conditions — otherwise every
+// reconcile would grow the slice and produce K8s status writes.
+func TestSetBranchProtectionPartialCondition_Idempotent(t *testing.T) {
+	cr := &v1alpha1.Repository{}
+	setBranchProtectionPartialCondition(context.Background(), cr, []string{"develop"})
+	setBranchProtectionPartialCondition(context.Background(), cr, []string{"develop"})
+
+	count := 0
+	for _, c := range cr.Status.Conditions {
+		if c.Type == "BranchProtectionPartial" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("BranchProtectionPartial conditions = %d, want 1", count)
 	}
 }


### PR DESCRIPTION
<!-- Fixes # -->

### Description of your changes

Skips branch protection rules (BPRs) whose target branch doesn't exist in the repository, instead of failing the entire reconcile with a 404 from `UpdateBranchProtection`. Surfaces the skipped branches via a `BranchProtectionPartial` condition on the CR.

**Motivation.** Today, a single `Repository` CR rule pointing at a branch the repo doesn't have (e.g. a `develop` rule on a freshly-created repo that only has `main`, or a rule pre-declared before its branch is created) causes the controller to call `UpdateBranchProtection(..., "develop", ...)`, receive a 404, and fail the reconcile. The 404 blocks every *other* BPR on the same Repository from being applied, pins the resource in NotReady, and burns API quota on every poll trying the same call. A single misconfigured rule poisons the whole repository sync.

**Approach.** Pre-filter CR rules to those whose target branch exists, before issuing any `UpdateBranchProtection` call:

- Refactored `listProtectedBranches` (paginated branches with `Protected=true`) into `listBranches`, which performs the same paginated call without the filter and returns both the protected subset and a set of all branch names. Same API page cost as before.
- New `filterMissingBranchProtectionRules(rules, existing)` drops rules whose branch isn't present, returning a sorted list of skipped branch names.
- Wired into Observe, Create, and Update paths.
- Skipped state surfaced via a `BranchProtectionPartial` condition on the CR. `status=True / reason=BranchesMissing` lists the missing branches in the message; `status=False / reason=AllBranchesPresent` when all rules apply. Crossplane's `SetConditions` dedupes identical writes, so steady-state reconciles don't thrash status and there is no event-storm on controller restarts.


**API quota math (per repo with N missing-branch rules).**

| Scenario | Before | After |
|---|---|---|
| Observe poll | 1 List + later N×404 in Update | 1 List + 0 wasted |
| Update apply | 1 List + 1st missing rule errors → other rules untried | 1 List + applies only existing rules |
| Create | 0 List + N×404 (one-shot) | 1 List + 0 wasted |
| No drift case | Stuck not-up-to-date loop forever | Reaches Ready=True; `WithEventFilter(DesiredStateChanged())` quiets the reconcile |

**Scope / non-goals.**

- Only branch protection rules. Rulesets target patterns rather than specific branches and don't have the 404 failure mode; out of scope.
- Orphan BPRs (BPRs whose branch was deleted via `allowDeletions: true` or via the rare "disable protection → delete branch → re-enable" sequence) are not cleaned up by this change. They can't be enumerated via the REST API today and the scenario is narrow enough that adding status-tracking machinery isn't justified. Documented as a known limitation.
- No CRD field additions. Purely controller-side. Existing manifests need no modification.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

**Unit tests.** New coverage in `internal/controller/repository/`:

- `TestFilterMissingBranchProtectionRules` — 4 cases (all-exist / some-missing-sorted / all-missing / empty). Mutation-verified by temporarily removing the map `delete` and the `sort.Strings` and watching the tests fail.
- `TestSetBranchProtectionPartialCondition` — empty skipped → False/`AllBranchesPresent`/empty message; non-empty skipped → True/`BranchesMissing`/message names branches.
- `TestSetBranchProtectionPartialCondition_Idempotent` — calling the helper twice with identical input must not append a duplicate condition. Mutation-verified by replacing `SetConditions` with `append` and watching the test fail.

**Real-org testing.** Scenarios run against a live GitHub org:

| Tier | Tests |
|---|---|
| A — core feature | Single missing-branch rule reaches Ready, late-arriving branch picks up the rule, multiple missing branches listed in one condition message |
| B — regression | All-branches-exist case unchanged, update existing BPR alongside a missing-branch BPR |
| C — corner cases | New repo with no commits and all BPRs missing branches, `allowDeletions: true` + actual branch deletion |

`make reviewable` clean.

[contribution process]: https://git.io/fj2m9