### PR TITLE
Wrap remaining GitHub API methods in RateLimitClient

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -134,9 +134,6 @@ func NewClient(creds string) (*Client, error) {
 	}
 
 	ghclient := github.NewClient(&http.Client{Transport: itr})
-	if err != nil {
-		return nil, err
-	}
 
 	return &Client{
 		Actions:       ghclient.Actions,

--- a/internal/clients/rate_limit_client.go
+++ b/internal/clients/rate_limit_client.go
@@ -259,6 +259,138 @@ func (rrc *RateLimitRepositoriesClient) Delete(ctx context.Context, owner, repo 
 	return resp, err
 }
 
+func (rrc *RateLimitRepositoriesClient) ListTeams(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
+	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.ListTeams", func() ([]*github.Team, *github.Response, error) {
+		return rrc.RepositoriesClient.ListTeams(ctx, owner, repo, opts)
+	})
+}
+
+func (rrc *RateLimitRepositoriesClient) ListCollaborators(ctx context.Context, owner, repo string, opts *github.ListCollaboratorsOptions) ([]*github.User, *github.Response, error) {
+	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.ListCollaborators", func() ([]*github.User, *github.Response, error) {
+		return rrc.RepositoriesClient.ListCollaborators(ctx, owner, repo, opts)
+	})
+}
+
+func (rrc *RateLimitRepositoriesClient) CreateFromTemplate(ctx context.Context, templateOwner, templateRepo string, templateRepoReq *github.TemplateRepoRequest) (*github.Repository, *github.Response, error) {
+	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.CreateFromTemplate", func() (*github.Repository, *github.Response, error) {
+		return rrc.RepositoriesClient.CreateFromTemplate(ctx, templateOwner, templateRepo, templateRepoReq)
+	})
+}
+
+func (rrc *RateLimitRepositoriesClient) CreateFork(ctx context.Context, owner, repo string, opts *github.RepositoryCreateForkOptions) (*github.Repository, *github.Response, error) {
+	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.CreateFork", func() (*github.Repository, *github.Response, error) {
+		return rrc.RepositoriesClient.CreateFork(ctx, owner, repo, opts)
+	})
+}
+
+func (rrc *RateLimitRepositoriesClient) AddCollaborator(ctx context.Context, owner, repo, user string, opts *github.RepositoryAddCollaboratorOptions) (*github.CollaboratorInvitation, *github.Response, error) {
+	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.AddCollaborator", func() (*github.CollaboratorInvitation, *github.Response, error) {
+		return rrc.RepositoriesClient.AddCollaborator(ctx, owner, repo, user, opts)
+	})
+}
+
+func (rrc *RateLimitRepositoriesClient) RemoveCollaborator(ctx context.Context, owner, repo, user string) (*github.Response, error) {
+	resp, err := rrc.RepositoriesClient.RemoveCollaborator(ctx, owner, repo, user)
+	recordResponse(rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.RemoveCollaborator", resp, err)
+	return resp, err
+}
+
+func (rrc *RateLimitRepositoriesClient) CreateHook(ctx context.Context, owner, repo string, hook *github.Hook) (*github.Hook, *github.Response, error) {
+	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.CreateHook", func() (*github.Hook, *github.Response, error) {
+		return rrc.RepositoriesClient.CreateHook(ctx, owner, repo, hook)
+	})
+}
+
+func (rrc *RateLimitRepositoriesClient) EditHook(ctx context.Context, owner, repo string, id int64, hook *github.Hook) (*github.Hook, *github.Response, error) {
+	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.EditHook", func() (*github.Hook, *github.Response, error) {
+		return rrc.RepositoriesClient.EditHook(ctx, owner, repo, id, hook)
+	})
+}
+
+func (rrc *RateLimitRepositoriesClient) DeleteHook(ctx context.Context, owner, repo string, id int64) (*github.Response, error) {
+	resp, err := rrc.RepositoriesClient.DeleteHook(ctx, owner, repo, id)
+	recordResponse(rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.DeleteHook", resp, err)
+	return resp, err
+}
+
+func (rrc *RateLimitRepositoriesClient) ListHooks(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.Hook, *github.Response, error) {
+	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.ListHooks", func() ([]*github.Hook, *github.Response, error) {
+		return rrc.RepositoriesClient.ListHooks(ctx, owner, repo, opts)
+	})
+}
+
+func (rrc *RateLimitRepositoriesClient) ListBranches(ctx context.Context, owner, repo string, opts *github.BranchListOptions) ([]*github.Branch, *github.Response, error) {
+	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.ListBranches", func() ([]*github.Branch, *github.Response, error) {
+		return rrc.RepositoriesClient.ListBranches(ctx, owner, repo, opts)
+	})
+}
+
+func (rrc *RateLimitRepositoriesClient) GetBranchProtection(ctx context.Context, owner, repo, branch string) (*github.Protection, *github.Response, error) {
+	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.GetBranchProtection", func() (*github.Protection, *github.Response, error) {
+		return rrc.RepositoriesClient.GetBranchProtection(ctx, owner, repo, branch)
+	})
+}
+
+func (rrc *RateLimitRepositoriesClient) UpdateBranchProtection(ctx context.Context, owner, repo, branch string, preq *github.ProtectionRequest) (*github.Protection, *github.Response, error) {
+	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.UpdateBranchProtection", func() (*github.Protection, *github.Response, error) {
+		return rrc.RepositoriesClient.UpdateBranchProtection(ctx, owner, repo, branch, preq)
+	})
+}
+
+func (rrc *RateLimitRepositoriesClient) RemoveBranchProtection(ctx context.Context, owner, repo, branch string) (*github.Response, error) {
+	resp, err := rrc.RepositoriesClient.RemoveBranchProtection(ctx, owner, repo, branch)
+	recordResponse(rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.RemoveBranchProtection", resp, err)
+	return resp, err
+}
+
+func (rrc *RateLimitRepositoriesClient) RequireSignaturesOnProtectedBranch(ctx context.Context, owner, repo, branch string) (*github.SignaturesProtectedBranch, *github.Response, error) {
+	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.RequireSignaturesOnProtectedBranch", func() (*github.SignaturesProtectedBranch, *github.Response, error) {
+		return rrc.RepositoriesClient.RequireSignaturesOnProtectedBranch(ctx, owner, repo, branch)
+	})
+}
+
+func (rrc *RateLimitRepositoriesClient) OptionalSignaturesOnProtectedBranch(ctx context.Context, owner, repo, branch string) (*github.Response, error) {
+	resp, err := rrc.RepositoriesClient.OptionalSignaturesOnProtectedBranch(ctx, owner, repo, branch)
+	recordResponse(rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.OptionalSignaturesOnProtectedBranch", resp, err)
+	return resp, err
+}
+
+func (rrc *RateLimitRepositoriesClient) GetAllRulesets(ctx context.Context, owner, repo string, includesParents bool) ([]*github.Ruleset, *github.Response, error) {
+	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.GetAllRulesets", func() ([]*github.Ruleset, *github.Response, error) {
+		return rrc.RepositoriesClient.GetAllRulesets(ctx, owner, repo, includesParents)
+	})
+}
+
+func (rrc *RateLimitRepositoriesClient) GetRuleset(ctx context.Context, owner, repo string, rulesetID int64, includesParents bool) (*github.Ruleset, *github.Response, error) {
+	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.GetRuleset", func() (*github.Ruleset, *github.Response, error) {
+		return rrc.RepositoriesClient.GetRuleset(ctx, owner, repo, rulesetID, includesParents)
+	})
+}
+
+func (rrc *RateLimitRepositoriesClient) CreateRuleset(ctx context.Context, owner, repo string, ruleset *github.Ruleset) (*github.Ruleset, *github.Response, error) {
+	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.CreateRuleset", func() (*github.Ruleset, *github.Response, error) {
+		return rrc.RepositoriesClient.CreateRuleset(ctx, owner, repo, ruleset)
+	})
+}
+
+func (rrc *RateLimitRepositoriesClient) UpdateRuleset(ctx context.Context, owner, repo string, rulesetID int64, ruleset *github.Ruleset) (*github.Ruleset, *github.Response, error) {
+	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.UpdateRuleset", func() (*github.Ruleset, *github.Response, error) {
+		return rrc.RepositoriesClient.UpdateRuleset(ctx, owner, repo, rulesetID, ruleset)
+	})
+}
+
+func (rrc *RateLimitRepositoriesClient) DeleteRuleset(ctx context.Context, owner, repo string, rulesetID int64) (*github.Response, error) {
+	resp, err := rrc.RepositoriesClient.DeleteRuleset(ctx, owner, repo, rulesetID)
+	recordResponse(rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.DeleteRuleset", resp, err)
+	return resp, err
+}
+
+func (rrc *RateLimitRepositoriesClient) ReplaceAllTopics(ctx context.Context, owner, repo string, topics []string) ([]string, *github.Response, error) {
+	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.ReplaceAllTopics", func() ([]string, *github.Response, error) {
+		return rrc.RepositoriesClient.ReplaceAllTopics(ctx, owner, repo, topics)
+	})
+}
+
 // RateLimitTeamsClient methods
 func (rtc *RateLimitTeamsClient) GetTeamBySlug(ctx context.Context, org, slug string) (*github.Team, *github.Response, error) {
 	return recordRateLimit(ctx, rtc.metrics, rtc.org, rtc.appID, rtc.installationID, rtc.cacheKey, "Teams.GetTeamBySlug", func() (*github.Team, *github.Response, error) {
@@ -281,6 +413,36 @@ func (rtc *RateLimitTeamsClient) EditTeamBySlug(ctx context.Context, org, slug s
 func (rtc *RateLimitTeamsClient) DeleteTeamBySlug(ctx context.Context, org, slug string) (*github.Response, error) {
 	resp, err := rtc.TeamsClient.DeleteTeamBySlug(ctx, org, slug)
 	recordResponse(rtc.metrics, rtc.org, rtc.appID, rtc.installationID, rtc.cacheKey, "Teams.DeleteTeamBySlug", resp, err)
+	return resp, err
+}
+
+func (rtc *RateLimitTeamsClient) ListTeamMembersBySlug(ctx context.Context, org, slug string, opts *github.TeamListTeamMembersOptions) ([]*github.User, *github.Response, error) {
+	return recordRateLimit(ctx, rtc.metrics, rtc.org, rtc.appID, rtc.installationID, rtc.cacheKey, "Teams.ListTeamMembersBySlug", func() ([]*github.User, *github.Response, error) {
+		return rtc.TeamsClient.ListTeamMembersBySlug(ctx, org, slug, opts)
+	})
+}
+
+func (rtc *RateLimitTeamsClient) AddTeamMembershipBySlug(ctx context.Context, org, slug, user string, opts *github.TeamAddTeamMembershipOptions) (*github.Membership, *github.Response, error) {
+	return recordRateLimit(ctx, rtc.metrics, rtc.org, rtc.appID, rtc.installationID, rtc.cacheKey, "Teams.AddTeamMembershipBySlug", func() (*github.Membership, *github.Response, error) {
+		return rtc.TeamsClient.AddTeamMembershipBySlug(ctx, org, slug, user, opts)
+	})
+}
+
+func (rtc *RateLimitTeamsClient) RemoveTeamMembershipBySlug(ctx context.Context, org, slug, user string) (*github.Response, error) {
+	resp, err := rtc.TeamsClient.RemoveTeamMembershipBySlug(ctx, org, slug, user)
+	recordResponse(rtc.metrics, rtc.org, rtc.appID, rtc.installationID, rtc.cacheKey, "Teams.RemoveTeamMembershipBySlug", resp, err)
+	return resp, err
+}
+
+func (rtc *RateLimitTeamsClient) AddTeamRepoBySlug(ctx context.Context, org, slug, owner, repo string, opts *github.TeamAddTeamRepoOptions) (*github.Response, error) {
+	resp, err := rtc.TeamsClient.AddTeamRepoBySlug(ctx, org, slug, owner, repo, opts)
+	recordResponse(rtc.metrics, rtc.org, rtc.appID, rtc.installationID, rtc.cacheKey, "Teams.AddTeamRepoBySlug", resp, err)
+	return resp, err
+}
+
+func (rtc *RateLimitTeamsClient) RemoveTeamRepoBySlug(ctx context.Context, org, slug, owner, repo string) (*github.Response, error) {
+	resp, err := rtc.TeamsClient.RemoveTeamRepoBySlug(ctx, org, slug, owner, repo)
+	recordResponse(rtc.metrics, rtc.org, rtc.appID, rtc.installationID, rtc.cacheKey, "Teams.RemoveTeamRepoBySlug", resp, err)
 	return resp, err
 }
 

--- a/internal/clients/wrapper_parity_test.go
+++ b/internal/clients/wrapper_parity_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clients
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestRateLimitClientWrapperParity asserts that every method on every service
+// interface in client.go has an explicit wrapper on the corresponding
+// RateLimit*Client struct in rate_limit_client.go.
+//
+// Each RateLimit*Client embeds the service interface, so a missing wrapper
+// compiles fine — the call falls through to the underlying go-github client
+// and bypasses both github_api_calls_total recording and the per-App quota
+// pool's response-header capture. The observability gap and picker blind
+// spot are silent, hence this parity test as a regression guard.
+func TestRateLimitClientWrapperParity(t *testing.T) {
+	pairings := map[string]string{
+		"ActionsClient":       "RateLimitActionsClient",
+		"DependabotClient":    "RateLimitDependabotClient",
+		"OrganizationsClient": "RateLimitOrganizationsClient",
+		"UsersClient":         "RateLimitUsersClient",
+		"TeamsClient":         "RateLimitTeamsClient",
+		"RepositoriesClient":  "RateLimitRepositoriesClient",
+	}
+
+	interfaceMethods := parseInterfaceMethods(t, "client.go")
+	wrapperMethods := parseStructMethods(t, "rate_limit_client.go")
+
+	for ifaceName, wrapperName := range pairings {
+		iface, ok := interfaceMethods[ifaceName]
+		if !ok {
+			t.Errorf("interface %s not found in client.go", ifaceName)
+			continue
+		}
+		wrapper, ok := wrapperMethods[wrapperName]
+		if !ok {
+			t.Errorf("struct %s not found in rate_limit_client.go", wrapperName)
+			continue
+		}
+
+		var missing []string
+		for m := range iface {
+			if _, ok := wrapper[m]; !ok {
+				missing = append(missing, m)
+			}
+		}
+		sort.Strings(missing)
+		if len(missing) > 0 {
+			t.Errorf("%s missing %d wrapper(s) for %s: %s",
+				wrapperName, len(missing), ifaceName, strings.Join(missing, ", "))
+		}
+	}
+}
+
+func parseInterfaceMethods(t *testing.T, file string) map[string]map[string]struct{} {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, file, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	out := map[string]map[string]struct{}{}
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			it, ok := ts.Type.(*ast.InterfaceType)
+			if !ok {
+				continue
+			}
+			methods := map[string]struct{}{}
+			for _, m := range it.Methods.List {
+				// Embedded interfaces have no Names; skip them.
+				for _, name := range m.Names {
+					methods[name.Name] = struct{}{}
+				}
+			}
+			out[ts.Name.Name] = methods
+		}
+	}
+	return out
+}
+
+func parseStructMethods(t *testing.T, file string) map[string]map[string]struct{} {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, file, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	out := map[string]map[string]struct{}{}
+	for _, decl := range f.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok || fd.Recv == nil || len(fd.Recv.List) == 0 {
+			continue
+		}
+		recvType := receiverTypeName(fd.Recv.List[0].Type)
+		if recvType == "" {
+			continue
+		}
+		if out[recvType] == nil {
+			out[recvType] = map[string]struct{}{}
+		}
+		out[recvType][fd.Name.Name] = struct{}{}
+	}
+	return out
+}
+
+// receiverTypeName extracts "T" from a receiver expression of the form
+// "*T" or "T". Returns "" for anything else.
+func receiverTypeName(expr ast.Expr) string {
+	if star, ok := expr.(*ast.StarExpr); ok {
+		if id, ok := star.X.(*ast.Ident); ok {
+			return id.Name
+		}
+		return ""
+	}
+	if id, ok := expr.(*ast.Ident); ok {
+		return id.Name
+	}
+	return ""
+}


### PR DESCRIPTION
## Problem

`RateLimit*Client` structs embed the service interface, so any method not explicitly wrapped silently falls through to the underlying go-github client. Coverage when rate-limit metrics were first introduced (#32) focused on the CRUD verbs of each interface, and subsequent PRs extended functionality without backfilling the wrapping. As a result, roughly two thirds of the methods on the Repositories and Teams interfaces fall through unwrapped today.

Consequence: calls to unwrapped methods don't increment `github_api_calls_total` and don't update the per-App quota pool's response-header snapshot, leaving the multi-App picker (#41) operating on partially stale data. The unwrapped set covers all branch protection, ruleset, hook, collaborator, team-membership, team-repo, and repo-level team-listing methods — which dominate per-Repository reconcile traffic in steady state.

## Change

Add explicit wrappers for all 27 missing methods — 22 on `RateLimitRepositoriesClient`, 5 on `RateLimitTeamsClient` — following the existing template:

- `recordRateLimit` for value-returning calls (`(T, *github.Response, error)`).
- `recordResponse` for `(*github.Response, error)` returns.

Add `internal/clients/wrapper_parity_test.go`: AST-based test that parses both files and fails listing any interface method without a corresponding wrapper. Prevents the gap from reopening when new methods are added.

Also removes an unreachable `if err != nil` block after `github.NewClient` in `NewClient`.

## Verification

- `make reviewable` green.
- New parity test passes; sanity-checked by temporarily deleting one wrapper to confirm the failure message is actionable.
- Locally observed newly-wrapped methods (`Repositories.ListTeams`, `ListCollaborators`, `ListBranches`) appearing in `github_api_calls_total` post-deploy.
- Wrappers are pure pass-throughs — no behavioral change to API call semantics.

## Test plan

- [ ] After deploy, confirm new method labels appear in `github_api_calls_total`.
- [ ] Confirm `(sum_limit - sum(github_rate_limit_remaining)) - sum(rate(github_api_calls_total[1h])) * 3600` settles near zero within ~1 hour.
- [ ] Watch `github_app_picker_picks_total` for unexpected concentration that would indicate the picker is routing differently with its new, more-accurate view.
