### PR TITLE
Refactor Organization enabled-repos to bulk Set; fix pagination bug and reconcile timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,66 @@ implements follwing objects with partial functionality:
   * role
 
 
+## Operational considerations
+
+### `--reconcile-timeout`
+
+The provider takes a `--reconcile-timeout` flag that bounds the time any
+single managed-resource reconcile (Observe + Create/Update/Delete) is
+allowed to run. The runtime cancels the reconcile's context when the
+deadline is reached.
+
+The `Organization` CR's `spec.forProvider.actions.enabledRepos` field
+lists the repositories that are allowed to run GitHub Actions at the
+organization level (this maps to GitHub's `selected_repository_ids`
+list under `Actions › General › Allow select repositories` in the org
+settings, and to the `actions/permissions/repositories` REST API). The
+two timeout-sensitive scenarios below both involve reconciling that
+list.
+
+**Default: `1m`.** Suitable for steady-state reconciliation and small
+spec changes. The default is **not** enough for two operational
+scenarios:
+
+1. **Cold bootstrap of an `Organization` CR with a large Actions
+   enabled-repos list.** On first reconcile the provider issues one
+   sequential `Repositories.Get` per repo in `actions.enabledRepos`
+   that is not already enabled in GitHub, to resolve names to numeric
+   IDs. At ~0.5s per call through the rate-limit-aware client this is
+   roughly `N × 0.5s`. An org bootstrapping with 200 enabled repos
+   takes ~100s — past the 60s budget — so the reconcile will time out
+   and retry on the next cycle. The system is **self-healing** across
+   cycles (each retry resolves a smaller remaining diff) but doesn't
+   converge in one shot.
+
+2. **Bulk spec edits to the Actions enabled-repos list.** Adding or
+   replacing tens of repos in an existing `Organization`'s
+   `actions.enabledRepos` triggers the same per-new-repo
+   `Repositories.Get` burst. Removals do not — repo IDs for
+   already-enabled repos come back free from the paginated
+   `ListEnabledReposInOrg` walk that the controller does anyway.
+
+Steady-state reconciles (no spec drift, or drift confined to
+description/secrets) cost a handful of API calls regardless of org
+size and fit comfortably in the default.
+
+**Raising it.** Pass `--reconcile-timeout=3m` (or whatever fits your
+worst-case bootstrap) on the provider deployment. A 3-minute budget
+covers ~300 sequential ID resolutions plus the usual overhead. Pick the
+smallest value that contains your operational worst case — larger
+timeouts let stuck reconciles hold a worker for longer before the
+runtime cancels them, which reduces overall throughput across all
+controllers.
+
+**Detecting it.** A reconcile that hits the deadline surfaces as
+`Synced=False` with `reason=ReconcileError, message="... context
+deadline exceeded"` on the CR's status, and a `Warning` event of type
+`CannotUpdateExternalResource`. If you see this on an `Organization`
+right after a large change to its Actions enabled-repos list, the
+timeout is the most likely cause; let the controller retry a couple
+of cycles before raising the flag.
+
+
 ## Developing
 
 To add a new resource follow these steps:

--- a/README.md
+++ b/README.md
@@ -40,9 +40,17 @@ The `Organization` CR's `spec.forProvider.actions.enabledRepos` field
 lists the repositories that are allowed to run GitHub Actions at the
 organization level (this maps to GitHub's `selected_repository_ids`
 list under `Actions › General › Allow select repositories` in the org
-settings, and to the `actions/permissions/repositories` REST API). The
-two timeout-sensitive scenarios below both involve reconciling that
-list.
+settings, and to the `actions/permissions/repositories` REST API).
+
+The field is **tri-state** — omitting it leaves the org's enabled list
+unmanaged, setting it to `[]` explicitly wipes the list (disabling
+Actions for every repo in the org), and a non-empty list reconciles
+the list to exactly those repositories. See the field's CRD docstring
+(`kubectl explain organization.spec.forProvider.actions.enabledRepos`)
+for the full contract.
+
+The two timeout-sensitive scenarios below both involve reconciling
+that list.
 
 **Default: `1m`.** Suitable for steady-state reconciliation and small
 spec changes. The default is **not** enough for two operational

--- a/apis/organizations/v1alpha1/organization_types.go
+++ b/apis/organizations/v1alpha1/organization_types.go
@@ -27,6 +27,23 @@ import (
 
 // ActionsConfiguration are the configurable fields of an Organization Actions.
 type ActionsConfiguration struct {
+	// EnabledRepos is the set of repositories allowed to run GitHub
+	// Actions at the organization level (equivalent to GitHub's
+	// "selected_repository_ids" list when the org's Actions permission
+	// policy is "selected"). The provider reconciles the org's enabled
+	// list to match this field via a single atomic PUT.
+	//
+	// The field is tri-state:
+	//   - omitted / nil: the provider does not manage the enabled list;
+	//     whatever is already configured on GitHub is left untouched.
+	//   - empty slice ([]): the provider sets the enabled list to empty,
+	//     disabling Actions for every repository in the org.
+	//   - non-empty: the provider sets the enabled list to exactly these
+	//     repositories, adding any missing and removing any extras.
+	//
+	// To stop managing the list, remove the field. Setting it to [] is
+	// an explicit "wipe" and will affect every repo in the org.
+	// +optional
 	EnabledRepos []ActionEnabledRepo `json:"enabledRepos,omitempty"`
 }
 

--- a/examples/organizations/organization.yaml
+++ b/examples/organizations/organization.yaml
@@ -2,10 +2,32 @@ apiVersion: organizations.github.crossplane.io/v1alpha1
 kind: Organization
 metadata:
   name: pgh-sample-organization
-spec: 
+spec:
   deletionPolicy: "Orphan"
   forProvider:
     description: this is a sample organization
+    actions:
+      # Repositories whose Actions runs are allowed at the org level. All
+      # three forms below are interchangeable; pick whichever fits the
+      # operator's model. Prefer repoRef/repoSelector over literal names
+      # when the target Repository is managed by another CR — references
+      # are validated at reconcile time, so a typo or a not-yet-created
+      # Repository surfaces as an explicit resolution error instead of a
+      # GitHub-side failure.
+      enabledRepos:
+        # Literal external-name (the GitHub repo name). Use when the repo
+        # is not managed by this provider.
+        - repo: my-awesome-repo
+        # Reference to a Repository CR by its Kubernetes name. The
+        # resolver fills `repo` from the CR's external-name on first
+        # reconcile.
+        - repoRef:
+            name: my-other-repo
+        # Selector over Repository CRs by label. Resolves to whichever
+        # single Repository matches.
+        - repoSelector:
+            matchLabels:
+              actions-enabled: "true"
     secrets:
       actionsSecrets:
         - name: foo-secret

--- a/examples/organizations/organization.yaml
+++ b/examples/organizations/organization.yaml
@@ -14,6 +14,12 @@ spec:
       # are validated at reconcile time, so a typo or a not-yet-created
       # Repository surfaces as an explicit resolution error instead of a
       # GitHub-side failure.
+      #
+      # The field is tri-state: omit it entirely to leave the org's
+      # enabled-repos list unmanaged; set it to [] to explicitly disable
+      # Actions on every repo; or list entries (as below) to reconcile
+      # the org to exactly that set. See the field's CRD docstring for
+      # the full contract.
       enabledRepos:
         # Literal external-name (the GitHub repo name). Use when the repo
         # is not managed by this provider.

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -40,6 +40,7 @@ type ActionsClient interface {
 	ListEnabledReposInOrg(ctx context.Context, owner string, opts *github.ListOptions) (*github.ActionsEnabledOnOrgRepos, *github.Response, error)
 	AddEnabledReposInOrg(ctx context.Context, owner string, repositoryID int64) (*github.Response, error)
 	RemoveEnabledReposInOrg(ctx context.Context, owner string, repositoryID int64) (*github.Response, error)
+	SetEnabledReposInOrg(ctx context.Context, owner string, repositoryIDs []int64) (*github.Response, error)
 	GetOrgSecret(ctx context.Context, org, name string) (*github.Secret, *github.Response, error)
 	ListSelectedReposForOrgSecret(ctx context.Context, org, name string, opts *github.ListOptions) (*github.SelectedReposList, *github.Response, error)
 	SetSelectedReposForOrgSecret(ctx context.Context, org, name string, ids github.SelectedRepoIDs) (*github.Response, error)

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -38,8 +38,6 @@ type Client struct {
 
 type ActionsClient interface {
 	ListEnabledReposInOrg(ctx context.Context, owner string, opts *github.ListOptions) (*github.ActionsEnabledOnOrgRepos, *github.Response, error)
-	AddEnabledReposInOrg(ctx context.Context, owner string, repositoryID int64) (*github.Response, error)
-	RemoveEnabledReposInOrg(ctx context.Context, owner string, repositoryID int64) (*github.Response, error)
 	SetEnabledReposInOrg(ctx context.Context, owner string, repositoryIDs []int64) (*github.Response, error)
 	GetOrgSecret(ctx context.Context, org, name string) (*github.Secret, *github.Response, error)
 	ListSelectedReposForOrgSecret(ctx context.Context, org, name string, opts *github.ListOptions) (*github.SelectedReposList, *github.Response, error)

--- a/internal/clients/fake/client.go
+++ b/internal/clients/fake/client.go
@@ -11,6 +11,7 @@ type MockActionsClient struct {
 	MockListEnabledReposInOrg           func(ctx context.Context, owner string, opts *github.ListOptions) (*github.ActionsEnabledOnOrgRepos, *github.Response, error)
 	MockAddEnabledReposInOrg            func(ctx context.Context, owner string, repositoryID int64) (*github.Response, error)
 	MockRemoveEnabledReposInOrg         func(ctx context.Context, owner string, repositoryID int64) (*github.Response, error)
+	MockSetEnabledReposInOrg            func(ctx context.Context, owner string, repositoryIDs []int64) (*github.Response, error)
 	MockGetOrgSecret                    func(ctx context.Context, org, name string) (*github.Secret, *github.Response, error)
 	MockListSelectedReposForOrgSecret   func(ctx context.Context, org, name string, opts *github.ListOptions) (*github.SelectedReposList, *github.Response, error)
 	MockSetSelectedReposForOrgSecret    func(ctx context.Context, org, name string, ids github.SelectedRepoIDs) (*github.Response, error)
@@ -32,6 +33,10 @@ func (m *MockActionsClient) AddEnabledReposInOrg(ctx context.Context, owner stri
 
 func (m *MockActionsClient) RemoveEnabledReposInOrg(ctx context.Context, owner string, repositoryID int64) (*github.Response, error) {
 	return m.MockRemoveEnabledReposInOrg(ctx, owner, repositoryID)
+}
+
+func (m *MockActionsClient) SetEnabledReposInOrg(ctx context.Context, owner string, repositoryIDs []int64) (*github.Response, error) {
+	return m.MockSetEnabledReposInOrg(ctx, owner, repositoryIDs)
 }
 
 func (m *MockActionsClient) GetOrgSecret(ctx context.Context, org, name string) (*github.Secret, *github.Response, error) {

--- a/internal/clients/fake/client.go
+++ b/internal/clients/fake/client.go
@@ -9,8 +9,6 @@ import (
 
 type MockActionsClient struct {
 	MockListEnabledReposInOrg           func(ctx context.Context, owner string, opts *github.ListOptions) (*github.ActionsEnabledOnOrgRepos, *github.Response, error)
-	MockAddEnabledReposInOrg            func(ctx context.Context, owner string, repositoryID int64) (*github.Response, error)
-	MockRemoveEnabledReposInOrg         func(ctx context.Context, owner string, repositoryID int64) (*github.Response, error)
 	MockSetEnabledReposInOrg            func(ctx context.Context, owner string, repositoryIDs []int64) (*github.Response, error)
 	MockGetOrgSecret                    func(ctx context.Context, org, name string) (*github.Secret, *github.Response, error)
 	MockListSelectedReposForOrgSecret   func(ctx context.Context, org, name string, opts *github.ListOptions) (*github.SelectedReposList, *github.Response, error)
@@ -25,14 +23,6 @@ type MockActionsClient struct {
 
 func (m *MockActionsClient) ListEnabledReposInOrg(ctx context.Context, owner string, opts *github.ListOptions) (*github.ActionsEnabledOnOrgRepos, *github.Response, error) {
 	return m.MockListEnabledReposInOrg(ctx, owner, opts)
-}
-
-func (m *MockActionsClient) AddEnabledReposInOrg(ctx context.Context, owner string, repositoryID int64) (*github.Response, error) {
-	return m.MockAddEnabledReposInOrg(ctx, owner, repositoryID)
-}
-
-func (m *MockActionsClient) RemoveEnabledReposInOrg(ctx context.Context, owner string, repositoryID int64) (*github.Response, error) {
-	return m.MockRemoveEnabledReposInOrg(ctx, owner, repositoryID)
 }
 
 func (m *MockActionsClient) SetEnabledReposInOrg(ctx context.Context, owner string, repositoryIDs []int64) (*github.Response, error) {

--- a/internal/clients/rate_limit_client.go
+++ b/internal/clients/rate_limit_client.go
@@ -472,6 +472,12 @@ func (rac *RateLimitActionsClient) RemoveEnabledReposInOrg(ctx context.Context, 
 	return resp, err
 }
 
+func (rac *RateLimitActionsClient) SetEnabledReposInOrg(ctx context.Context, owner string, repositoryIDs []int64) (*github.Response, error) {
+	resp, err := rac.ActionsClient.SetEnabledReposInOrg(ctx, owner, repositoryIDs)
+	recordResponse(rac.metrics, rac.org, rac.appID, rac.installationID, rac.cacheKey, "Actions.SetEnabledReposInOrg", resp, err)
+	return resp, err
+}
+
 func (rac *RateLimitActionsClient) GetOrgSecret(ctx context.Context, org, name string) (*github.Secret, *github.Response, error) {
 	return recordRateLimit(ctx, rac.metrics, rac.org, rac.appID, rac.installationID, rac.cacheKey, "Actions.GetOrgSecret", func() (*github.Secret, *github.Response, error) {
 		return rac.ActionsClient.GetOrgSecret(ctx, org, name)

--- a/internal/clients/rate_limit_client.go
+++ b/internal/clients/rate_limit_client.go
@@ -460,18 +460,6 @@ func (rac *RateLimitActionsClient) ListEnabledReposInOrg(ctx context.Context, ow
 	})
 }
 
-func (rac *RateLimitActionsClient) AddEnabledReposInOrg(ctx context.Context, owner string, repositoryID int64) (*github.Response, error) {
-	resp, err := rac.ActionsClient.AddEnabledReposInOrg(ctx, owner, repositoryID)
-	recordResponse(rac.metrics, rac.org, rac.appID, rac.installationID, rac.cacheKey, "Actions.AddEnabledReposInOrg", resp, err)
-	return resp, err
-}
-
-func (rac *RateLimitActionsClient) RemoveEnabledReposInOrg(ctx context.Context, owner string, repositoryID int64) (*github.Response, error) {
-	resp, err := rac.ActionsClient.RemoveEnabledReposInOrg(ctx, owner, repositoryID)
-	recordResponse(rac.metrics, rac.org, rac.appID, rac.installationID, rac.cacheKey, "Actions.RemoveEnabledReposInOrg", resp, err)
-	return resp, err
-}
-
 func (rac *RateLimitActionsClient) SetEnabledReposInOrg(ctx context.Context, owner string, repositoryIDs []int64) (*github.Response, error) {
 	resp, err := rac.ActionsClient.SetEnabledReposInOrg(ctx, owner, repositoryIDs)
 	recordResponse(rac.metrics, rac.org, rac.appID, rac.installationID, rac.cacheKey, "Actions.SetEnabledReposInOrg", resp, err)

--- a/internal/controller/organization/organization.go
+++ b/internal/controller/organization/organization.go
@@ -35,7 +35,6 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/provider-github/internal/telemetry"
-	"github.com/crossplane/provider-github/internal/util"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	pointer "k8s.io/utils/ptr"
@@ -243,18 +242,14 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	// To use this function, the organization permission policy for enabled_repositories must be configured to selected, otherwise you get error 409 Conflict
 	if cr.Spec.ForProvider.Actions.EnabledRepos != nil {
-		aResp, _, err := c.github.Actions.ListEnabledReposInOrg(ctx, name, &github.ListOptions{PerPage: 100})
-
+		repos, err := listEnabledReposInOrg(ctx, c.github, name)
 		if err != nil {
 			return managed.ExternalObservation{}, err
 		}
 
 		crARepos := getSortedEnabledReposFromCr(cr.Spec.ForProvider.Actions.EnabledRepos)
-		aRepos := getSortedRepoNames(aResp.Repositories)
+		aRepos := getSortedRepoNames(repos)
 
-		if err != nil {
-			return managed.ExternalObservation{}, err
-		}
 		if !reflect.DeepEqual(aRepos, crARepos) {
 			return notUpToDate, nil
 		}
@@ -328,13 +323,8 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalUpdate{}, err
 	}
 
-	missingReposIds, toDeleteReposIds, err := getMissingAndToDeleteRepos(ctx, gh, name, cr)
-	if err != nil {
-		return managed.ExternalUpdate{}, err
-	}
 	if cr.Spec.ForProvider.Actions.EnabledRepos != nil {
-		err = updateRepos(ctx, gh, name, missingReposIds, toDeleteReposIds)
-		if err != nil {
+		if err := setEnabledReposForActions(ctx, gh, name, cr); err != nil {
 			return managed.ExternalUpdate{}, err
 		}
 	}
@@ -386,84 +376,59 @@ func getSortedRepoNames(repos []*github.Repository) []string {
 	return repoNames
 }
 
-func getUpdateRepoIds(ctx context.Context, repoCache *repositoryCache, crRepos []string, aRepos []string) ([]int64, error) {
-	var updateRepos []string
-	for _, repo := range crRepos {
-		// Check if the repository from CRD is not in GitHub
-		if !util.Contains(aRepos, repo) {
-			updateRepos = append(updateRepos, repo)
+// listEnabledReposInOrg returns every repository enabled for Actions in
+// the given organization, iterating through all pages. The single-page
+// shape of github.Actions.ListEnabledReposInOrg silently truncates the
+// result to one page, which produces a phantom diff against the CR's
+// enabled-repos list and triggers idempotent re-adds on every reconcile
+// when the org has more than 100 enabled repos.
+func listEnabledReposInOrg(ctx context.Context, gh *ghclient.RateLimitClient, org string) ([]*github.Repository, error) {
+	opts := &github.ListOptions{PerPage: 100}
+	var all []*github.Repository
+	for {
+		resp, httpResp, err := gh.Actions.ListEnabledReposInOrg(ctx, org, opts)
+		if err != nil {
+			return nil, err
 		}
+		all = append(all, resp.Repositories...)
+		if httpResp.NextPage == 0 {
+			break
+		}
+		opts.Page = httpResp.NextPage
 	}
-	if len(updateRepos) == 0 {
-		return []int64{}, nil
-	}
-
-	// Use batch repository ID lookup with caching
-	return repoCache.batchGetRepositoryIDs(ctx, updateRepos)
+	return all, nil
 }
 
-func getMissingAndToDeleteRepos(ctx context.Context, gh *ghclient.RateLimitClient, name string, cr *v1alpha1.Organization) ([]int64, []int64, error) {
+// setEnabledReposForActions reconciles the org's Actions-enabled repo list
+// to match the CR spec using a single PUT call instead of per-repo
+// Add/Remove. To avoid an unnecessary write when the diff Observe saw is
+// unrelated to enabledRepos (e.g. only description or secrets drifted),
+// it first lists the current state and skips the Set when names match.
+func setEnabledReposForActions(ctx context.Context, gh *ghclient.RateLimitClient, name string, cr *v1alpha1.Organization) error {
 	crARepos := getSortedEnabledReposFromCr(cr.Spec.ForProvider.Actions.EnabledRepos)
 
 	// To use this function, the organization permission policy for enabled_repositories must be configured to selected, otherwise you get error 409 Conflict
-	aResp, _, err := gh.Actions.ListEnabledReposInOrg(ctx, name, &github.ListOptions{PerPage: 100})
+	repos, err := listEnabledReposInOrg(ctx, gh, name)
 	if err != nil {
-		return nil, nil, err
+		return err
+	}
+	if reflect.DeepEqual(crARepos, getSortedRepoNames(repos)) {
+		return nil
 	}
 
-	// Extract repository names from the list
-	aRepos := getSortedRepoNames(aResp.Repositories)
-
-	// Create repository cache for this reconciliation
 	repoCache := newRepositoryCache(gh, name)
-
-	missingReposIds, err := getUpdateRepoIds(ctx, repoCache, crARepos, aRepos)
+	// Seed the cache from the list we already have. Without this, every
+	// Update would re-fetch IDs for repos that are already enabled — a
+	// burst of N Repositories.Get calls on an org with many enabled repos.
+	for _, r := range repos {
+		repoCache.cache[r.GetName()] = r.GetID()
+	}
+	ids, err := repoCache.batchGetRepositoryIDs(ctx, crARepos)
 	if err != nil {
-		return nil, nil, err
+		return err
 	}
-
-	toDeleteReposIds, err := getUpdateRepoIds(ctx, repoCache, aRepos, crARepos)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return missingReposIds, toDeleteReposIds, nil
-}
-
-func updateRepos(ctx context.Context, gh *ghclient.RateLimitClient, name string, missingReposIds []int64, toDeleteReposIds []int64) error {
-	if len(missingReposIds) > 0 {
-		for _, missingRepo := range missingReposIds {
-			// Check for context timeout
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			default:
-			}
-
-			_, err := gh.Actions.AddEnabledReposInOrg(ctx, name, missingRepo)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	if len(toDeleteReposIds) > 0 {
-		for _, toDeleteRepo := range toDeleteReposIds {
-			// Check for context timeout
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			default:
-			}
-
-			_, err := gh.Actions.RemoveEnabledReposInOrg(ctx, name, toDeleteRepo)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
+	_, err = gh.Actions.SetEnabledReposInOrg(ctx, name, ids)
+	return err
 }
 
 func getOrgSecretsMapFromCr(ctx context.Context, gh *ghclient.RateLimitClient, org string, secrets []v1alpha1.OrgSecret) (map[string][]int64, error) {

--- a/internal/controller/organization/organization_test.go
+++ b/internal/controller/organization/organization_test.go
@@ -165,7 +165,7 @@ func TestObserve(t *testing.T) {
 						},
 						Actions: &fake.MockActionsClient{
 							MockListEnabledReposInOrg: func(ctx context.Context, owner string, opts *github.ListOptions) (*github.ActionsEnabledOnOrgRepos, *github.Response, error) {
-								return githubOrgRepoActions(), nil, nil
+								return githubOrgRepoActions(), fake.GenerateEmptyResponse(), nil
 							},
 							MockGetOrgSecret: func(ctx context.Context, org, name string) (*github.Secret, *github.Response, error) {
 								return nil, fake.GenerateEmptyResponse(), nil
@@ -213,7 +213,7 @@ func TestObserve(t *testing.T) {
 						},
 						Actions: &fake.MockActionsClient{
 							MockListEnabledReposInOrg: func(ctx context.Context, owner string, opts *github.ListOptions) (*github.ActionsEnabledOnOrgRepos, *github.Response, error) {
-								return githubOrgRepoActions(), nil, nil
+								return githubOrgRepoActions(), fake.GenerateEmptyResponse(), nil
 							},
 							MockGetOrgSecret: func(ctx context.Context, org, name string) (*github.Secret, *github.Response, error) {
 								return githubOrgSecret(), fake.GenerateEmptyResponse(), nil
@@ -314,5 +314,133 @@ func TestObserve(t *testing.T) {
 				t.Errorf("\n%s\ne.Observe(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
+	}
+}
+
+// listEnabledReposInOrg must iterate beyond the first page when GitHub
+// returns NextPage > 0. Without pagination, only page 1 is visible to
+// the diff against the CR's enabled-repos list, every CR-declared repo
+// past page 1 looks "missing", and the controller burns calls
+// re-Adding repos that are already enabled.
+func TestListEnabledReposInOrg_Paginates(t *testing.T) {
+	pages := [][]*github.Repository{
+		{{Name: github.String("a")}, {Name: github.String("b")}},
+		{{Name: github.String("c")}},
+	}
+	calls := 0
+	gh := &ghclient.RateLimitClient{
+		Client: &ghclient.Client{
+			Actions: &fake.MockActionsClient{
+				MockListEnabledReposInOrg: func(ctx context.Context, owner string, opts *github.ListOptions) (*github.ActionsEnabledOnOrgRepos, *github.Response, error) {
+					i := calls
+					calls++
+					resp := &github.ActionsEnabledOnOrgRepos{Repositories: pages[i]}
+					httpResp := fake.GenerateEmptyResponse()
+					if i < len(pages)-1 {
+						httpResp.NextPage = i + 2
+					}
+					return resp, httpResp, nil
+				},
+			},
+		},
+	}
+
+	got, err := listEnabledReposInOrg(context.Background(), gh, "test-org")
+	if err != nil {
+		t.Fatalf("listEnabledReposInOrg: %v", err)
+	}
+	if calls != len(pages) {
+		t.Errorf("upstream called %d times, want %d (loop exited early — pagination broken)", calls, len(pages))
+	}
+	if len(got) != 3 {
+		t.Fatalf("returned %d repos, want 3 (page contents not concatenated)", len(got))
+	}
+	names := []string{*got[0].Name, *got[1].Name, *got[2].Name}
+	want := []string{"a", "b", "c"}
+	if diff := cmp.Diff(want, names); diff != "" {
+		t.Errorf("names mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// setEnabledReposForActions must skip the PUT when the org's current
+// enabled-repos list already matches the CR. This protects against
+// wasteful idempotent writes when Observe flagged the CR as out-of-date
+// for some other reason (e.g. description or secrets drifted).
+func TestSetEnabledReposForActions_SkipsWhenAlreadyMatching(t *testing.T) {
+	setCalled := false
+	gh := &ghclient.RateLimitClient{
+		Client: &ghclient.Client{
+			Actions: &fake.MockActionsClient{
+				MockListEnabledReposInOrg: func(ctx context.Context, owner string, opts *github.ListOptions) (*github.ActionsEnabledOnOrgRepos, *github.Response, error) {
+					return &github.ActionsEnabledOnOrgRepos{
+						Repositories: []*github.Repository{{Name: github.String("r1")}, {Name: github.String("r2")}},
+					}, fake.GenerateEmptyResponse(), nil
+				},
+				MockSetEnabledReposInOrg: func(ctx context.Context, owner string, ids []int64) (*github.Response, error) {
+					setCalled = true
+					return fake.GenerateEmptyResponse(), nil
+				},
+			},
+		},
+	}
+	cr := organization([]string{"r1", "r2"})
+	if err := setEnabledReposForActions(context.Background(), gh, org, cr); err != nil {
+		t.Fatalf("setEnabledReposForActions: %v", err)
+	}
+	if setCalled {
+		t.Error("SetEnabledReposInOrg was called even though current state matched CR — wastes one API call per Update when the drift is elsewhere")
+	}
+}
+
+// setEnabledReposForActions must call SetEnabledReposInOrg exactly once
+// with the IDs of all repos in the CR spec, and it must seed the
+// repo-name→ID cache from the list response so it only fetches IDs for
+// newly-added repos. Without that optimization, every Update on a large
+// org would re-fetch every repo's ID — O(N) avoidable Get calls.
+func TestSetEnabledReposForActions_CallsSetWithResolvedIDs(t *testing.T) {
+	idR1, idR2 := int64(11), int64(22)
+	var setIDs []int64
+	setCalls := 0
+	var lookedUp []string
+	gh := &ghclient.RateLimitClient{
+		Client: &ghclient.Client{
+			Actions: &fake.MockActionsClient{
+				MockListEnabledReposInOrg: func(ctx context.Context, owner string, opts *github.ListOptions) (*github.ActionsEnabledOnOrgRepos, *github.Response, error) {
+					// Org currently has only r1 (with ID, as real GitHub returns); CR wants r1+r2.
+					return &github.ActionsEnabledOnOrgRepos{
+						Repositories: []*github.Repository{{Name: github.String("r1"), ID: &idR1}},
+					}, fake.GenerateEmptyResponse(), nil
+				},
+				MockSetEnabledReposInOrg: func(ctx context.Context, owner string, ids []int64) (*github.Response, error) {
+					setCalls++
+					setIDs = append([]int64(nil), ids...)
+					return fake.GenerateEmptyResponse(), nil
+				},
+			},
+			Repositories: &fake.MockRepositoriesClient{
+				MockGet: func(ctx context.Context, owner, repoName string) (*github.Repository, *github.Response, error) {
+					lookedUp = append(lookedUp, repoName)
+					if repoName == "r2" {
+						return &github.Repository{ID: &idR2, Name: github.String("r2")}, fake.GenerateEmptyResponse(), nil
+					}
+					t.Fatalf("unexpected repo lookup: %s (cache seeding should have made this unnecessary)", repoName)
+					return nil, nil, nil
+				},
+			},
+		},
+	}
+	cr := organization([]string{"r1", "r2"})
+	if err := setEnabledReposForActions(context.Background(), gh, org, cr); err != nil {
+		t.Fatalf("setEnabledReposForActions: %v", err)
+	}
+	if setCalls != 1 {
+		t.Errorf("SetEnabledReposInOrg called %d times, want 1 (single bulk replace is the point of Option 1)", setCalls)
+	}
+	want := []int64{idR1, idR2}
+	if diff := cmp.Diff(want, setIDs); diff != "" {
+		t.Errorf("Set IDs mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{"r2"}, lookedUp); diff != "" {
+		t.Errorf("Repositories.Get lookups mismatch (-want +got):\n%s\nCache seeding from listEnabledReposInOrg result must skip already-enabled repos.", diff)
 	}
 }

--- a/internal/controller/organization/organization_test.go
+++ b/internal/controller/organization/organization_test.go
@@ -18,6 +18,8 @@ package organization
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/crossplane/provider-github/apis/organizations/v1alpha1"
@@ -443,4 +445,115 @@ func TestSetEnabledReposForActions_CallsSetWithResolvedIDs(t *testing.T) {
 	if diff := cmp.Diff([]string{"r2"}, lookedUp); diff != "" {
 		t.Errorf("Repositories.Get lookups mismatch (-want +got):\n%s\nCache seeding from listEnabledReposInOrg result must skip already-enabled repos.", diff)
 	}
+}
+
+// setEnabledReposForActions must surface a pagination error from
+// listEnabledReposInOrg without calling Set. A silent partial-page
+// result would leak into the diff and could trigger a wrong Set call
+// against a truncated view of the enabled-repos list.
+func TestSetEnabledReposForActions_PaginationErrorMidWalk(t *testing.T) {
+	listCalls := 0
+	setCalled := false
+	gh := &ghclient.RateLimitClient{
+		Client: &ghclient.Client{
+			Actions: &fake.MockActionsClient{
+				MockListEnabledReposInOrg: func(ctx context.Context, owner string, opts *github.ListOptions) (*github.ActionsEnabledOnOrgRepos, *github.Response, error) {
+					listCalls++
+					if listCalls == 1 {
+						// Page 1: return some repos and signal there's a next page.
+						r := fake.GenerateEmptyResponse()
+						r.NextPage = 2
+						return &github.ActionsEnabledOnOrgRepos{Repositories: []*github.Repository{{Name: github.String("r1")}}}, r, nil
+					}
+					// Page 2: simulate an API error mid-walk.
+					return nil, fake.GenerateEmptyResponse(), errors.New("github: 503 service unavailable")
+				},
+				MockSetEnabledReposInOrg: func(ctx context.Context, owner string, ids []int64) (*github.Response, error) {
+					setCalled = true
+					return fake.GenerateEmptyResponse(), nil
+				},
+			},
+		},
+	}
+	cr := organization([]string{"r1", "r2"})
+	err := setEnabledReposForActions(context.Background(), gh, org, cr)
+	if err == nil {
+		t.Fatal("expected pagination error to surface; silent partial pages would let the helper Set a wrong list")
+	}
+	if setCalled {
+		t.Error("SetEnabledReposInOrg was called despite a partial-page error — the desired-state PUT must not fire on incomplete diff input")
+	}
+}
+
+// setEnabledReposForActions must surface a Set error verbatim.
+// Update() relies on the helper's error to decide whether to mark the
+// CR Synced=False, so swallowing a Set failure would silently mislabel
+// state as in-sync.
+func TestSetEnabledReposForActions_SetErrorPropagates(t *testing.T) {
+	wantErr := errors.New("github: 422 invalid repository id")
+	gh := &ghclient.RateLimitClient{
+		Client: &ghclient.Client{
+			Actions: &fake.MockActionsClient{
+				// CR wants only r1; GH has r1+r2 enabled. Names differ, so
+				// Set fires (with r1's resolved ID from the seeded cache).
+				MockListEnabledReposInOrg: func(ctx context.Context, owner string, opts *github.ListOptions) (*github.ActionsEnabledOnOrgRepos, *github.Response, error) {
+					return &github.ActionsEnabledOnOrgRepos{
+						Repositories: []*github.Repository{
+							{Name: github.String("r1"), ID: github.Int64(11)},
+							{Name: github.String("r2"), ID: github.Int64(22)},
+						},
+					}, fake.GenerateEmptyResponse(), nil
+				},
+				MockSetEnabledReposInOrg: func(ctx context.Context, owner string, ids []int64) (*github.Response, error) {
+					return fake.GenerateEmptyResponse(), wantErr
+				},
+			},
+		},
+	}
+	cr := organization([]string{"r1"})
+	err := setEnabledReposForActions(context.Background(), gh, org, cr)
+	if err == nil || !errorContains(err, "422") {
+		t.Fatalf("expected Set error to bubble up unchanged, got: %v", err)
+	}
+}
+
+// setEnabledReposForActions must surface an error from the per-repo
+// Repositories.Get fallback (cache miss path). A swallow here would
+// produce zero-value IDs in the Set call, which GitHub rejects — but
+// would manifest as an unrelated 422, not the actual root cause.
+func TestSetEnabledReposForActions_GetErrorPropagates(t *testing.T) {
+	wantErr := errors.New("github: 404 not found")
+	setCalled := false
+	gh := &ghclient.RateLimitClient{
+		Client: &ghclient.Client{
+			Actions: &fake.MockActionsClient{
+				MockListEnabledReposInOrg: func(ctx context.Context, owner string, opts *github.ListOptions) (*github.ActionsEnabledOnOrgRepos, *github.Response, error) {
+					return &github.ActionsEnabledOnOrgRepos{
+						Repositories: []*github.Repository{{Name: github.String("r1"), ID: github.Int64(11)}},
+					}, fake.GenerateEmptyResponse(), nil
+				},
+				MockSetEnabledReposInOrg: func(ctx context.Context, owner string, ids []int64) (*github.Response, error) {
+					setCalled = true
+					return fake.GenerateEmptyResponse(), nil
+				},
+			},
+			Repositories: &fake.MockRepositoriesClient{
+				MockGet: func(ctx context.Context, owner, repoName string) (*github.Repository, *github.Response, error) {
+					return nil, fake.GenerateEmptyResponse(), wantErr
+				},
+			},
+		},
+	}
+	cr := organization([]string{"r1", "r2"}) // r2 is a cache miss → triggers Get → returns error
+	err := setEnabledReposForActions(context.Background(), gh, org, cr)
+	if err == nil || !errorContains(err, "404") {
+		t.Fatalf("expected Get error to surface, got: %v", err)
+	}
+	if setCalled {
+		t.Error("SetEnabledReposInOrg was called despite ID-resolution failure — that would have produced a malformed PUT and a confusing GitHub-side error")
+	}
+}
+
+func errorContains(err error, substr string) bool {
+	return err != nil && strings.Contains(err.Error(), substr)
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -80,16 +80,6 @@ func MergeMaps(m1 map[string]string, m2 map[string]string) map[string]string {
 	return merged
 }
 
-// Contains function to check if a string slice contains a specific string
-func Contains(slice []string, str string) bool {
-	for _, s := range slice {
-		if s == str {
-			return true
-		}
-	}
-	return false
-}
-
 func DiffRepoWebhooks(a, b map[string]v1alpha1.RepositoryWebhook) (map[string]v1alpha1.RepositoryWebhook, map[string]v1alpha1.RepositoryWebhook, map[string]v1alpha1.RepositoryWebhook) {
 	inANotInB := make(map[string]v1alpha1.RepositoryWebhook)
 	inBNotInA := make(map[string]v1alpha1.RepositoryWebhook)
@@ -241,12 +231,6 @@ func ToIntPtr(i int) *int {
 	return &i
 }
 
-// ToInt64Ptr is a helper function that takes an int64 'i' as input and returns a pointer to 'i'.
-// This can be useful when you want to create a pointer to an int64 value.
-func ToInt64Ptr(i int64) *int64 {
-	return &i
-}
-
 // ToStringPtr is a helper function that takes a string 's' as input and returns a pointer to 's'.
 // This can be useful when you want to create a pointer to a string value.
 func ToStringPtr(s string) *string {
@@ -270,13 +254,6 @@ func StringDerefToPointer(ptr *string, def string) *string {
 // IntDerefToPointer is a helper function that dereferences a pointer to an int 'ptr',
 // and returns a new pointer to the resulting int. If 'ptr' is nil, it uses 'def' as a default value.
 func IntDerefToPointer(ptr *int, def int) *int {
-	i := pointer.Deref(ptr, def)
-	return &i
-}
-
-// Int64DerefToPointer is a helper function that dereferences a pointer to an int64 'ptr',
-// and returns a new pointer to the resulting int64. If 'ptr' is nil, it uses 'def' as a default value.
-func Int64DerefToPointer(ptr *int64, def int64) *int64 {
 	i := pointer.Deref(ptr, def)
 	return &i
 }

--- a/package/crds/organizations.github.crossplane.io_organizations.yaml
+++ b/package/crds/organizations.github.crossplane.io_organizations.yaml
@@ -79,6 +79,25 @@ spec:
                       of an Organization Actions.
                     properties:
                       enabledRepos:
+                        description: |-
+                          EnabledRepos is the set of repositories allowed to run GitHub
+                          Actions at the organization level (equivalent to GitHub's
+                          "selected_repository_ids" list when the org's Actions permission
+                          policy is "selected"). The provider reconciles the org's enabled
+                          list to match this field via a single atomic PUT.
+
+
+                          The field is tri-state:
+                            - omitted / nil: the provider does not manage the enabled list;
+                              whatever is already configured on GitHub is left untouched.
+                            - empty slice ([]): the provider sets the enabled list to empty,
+                              disabling Actions for every repository in the org.
+                            - non-empty: the provider sets the enabled list to exactly these
+                              repositories, adding any missing and removing any extras.
+
+
+                          To stop managing the list, remove the field. Setting it to [] is
+                          an explicit "wipe" and will affect every repo in the org.
                         items:
                           properties:
                             repo:


### PR DESCRIPTION
## Summary

- Replace the per-repo `Actions.AddEnabledReposInOrg` / `RemoveEnabledReposInOrg` loops in the `Organization` controller's Update path with a single atomic `Actions.SetEnabledReposInOrg` PUT.
- Fix pagination in `listEnabledReposInOrg` so Observe's diff is computed against the complete server-side state, not just the first page.
- Seed the per-reconcile repository name → ID cache from the list response so the Set call only fetches IDs for repos newly added to the CR.

## Problem

Two compounding issues affected `Organization` CRs whose `actions.enabledRepos` list spans more than one page of the GitHub API (≥100 enabled repos):

1. **Truncated diff.** The previous `Actions.ListEnabledReposInOrg` call returned only the first page silently. Observe compared the CR's full list against a server view truncated to 100 entries; every CR repo past page 1 was flagged as "missing" on every reconcile. Update then re-issued idempotent `AddEnabledReposInOrg` calls for each — burning rate-limit quota indefinitely without ever converging.
2. **Reconcile timeout.** Even when the diff was real, the per-repo Add/Remove loops at the rate-limit client's pace did not fit in the default 60s `--reconcile-timeout` on orgs with many enabled repos. The controller would re-enter the same chunk on every retry without ever reaching steady state.

A secondary correctness issue compounded both: the per-repo loop is non-atomic, so a partial failure (one bad ID, one transient 5xx) could leave the org in an in-between state that matches neither the previous nor the new desired set.

## What changes

In `internal/controller/organization/organization.go`:

- `listEnabledReposInOrg` now walks all pages.
- `setEnabledReposForActions` replaces `getMissingAndToDeleteRepos` plus the Add/Remove loops:
  - Pre-seeds the per-reconcile ID cache from the list response (every currently-enabled repo's ID is already in the response payload, so look-up cost on the remove path drops to zero).
  - Resolves any remaining IDs via `Repositories.Get` — typically zero in steady state, only the diff size on real spec changes.
  - Calls `Actions.SetEnabledReposInOrg` once with the full desired set, replacing GitHub's enabled list atomically.

Atomic Set fits the declarative semantics of a managed resource: either the desired state is achieved or the previous state is preserved.

The new `SetEnabledReposInOrg` is wrapped in `RateLimitActionsClient` for metrics and exposed via `Client.Actions` / its mock in `internal/clients/fake`.

## Doc updates

- `README.md` gains an **Operational considerations** section covering `--reconcile-timeout`: when the default 1m is sufficient, the two scenarios that exceed it (cold bootstrap and bulk spec edits), how to raise the flag, and the throughput tradeoff of doing so.
- `examples/organizations/organization.yaml` now demonstrates all three forms of `ActionEnabledRepo` (literal name, `repoRef`, `repoSelector`) with a note recommending references when the target Repository is also a CR — references are validated at reconcile time, which pairs naturally with bulk Set's atomic semantics.

## Cleanup

`internal/util` drops three unused exported helpers (`Contains`, `ToInt64Ptr`, `Int64DerefToPointer`). `Contains` was the helper the previous per-repo path used to compute the missing/to-delete sets; it has no other callers. The other two were already orphans and are removed opportunistically.

## Test plan

- [x] Unit tests for `setEnabledReposForActions`:
  - skips the Set call when the current enabled list already matches the CR (avoids wasteful idempotent writes when the diff Observe saw is unrelated, e.g. description-only).
  - calls Set exactly once with the resolved IDs and only `Repositories.Get`s repos not already in the seeded cache.
- [x] Unit test for `listEnabledReposInOrg` pagination (verifies the helper walks `NextPage` until exhausted and concatenates results).
- [x] End-to-end against a 105-repo `Organization` CR in a kind cluster:
  - initial bootstrap (1 → 105 enabled repos) converges across one or two reconciles (the first may hit the 60s timeout; the second completes).
  - single-repo add and remove each produce exactly one Set call and at most one `Repositories.Get`.
  - steady-state reconciles after convergence are silent on Add / Remove / Set; only the paginated Observe walk fires.
- [x] `make lint` clean. Full unit-test suite passes.

## Known follow-ups (out of scope here)

- Cold bootstrap of an Organization CR with very large `enabledRepos` (hundreds of repos) can still exceed `--reconcile-timeout=1m` because of sequential `Repositories.Get` calls for ID resolution. The controller is self-healing across reconciles, and the new README section explains how to raise the flag. A future change could replace the sequential resolution with a bulk GraphQL lookup (one POST resolves N names), making the bootstrap fit in a single budget.
