### PR TITLE
Document supported resources and required GitHub App permissions

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -1,0 +1,51 @@
+# Required GitHub App permissions
+
+`provider-github` authenticates as a [GitHub App](https://docs.github.com/en/apps/creating-github-apps)
+installed on the organization it manages. The App must be granted the
+following permissions:
+
+## Repository permissions
+
+| Permission     | Access         | Why                                                                      |
+| -------------- | -------------- | ------------------------------------------------------------------------ |
+| Metadata       | Read           | Mandatory for every GitHub App; used by every controller for repo lookups |
+| Contents       | Read           | Listing repository branches                                              |
+| Administration | Read and write | Repository create/delete, settings, topics, collaborators, team access, branch protection rules, rulesets |
+| Webhooks       | Read and write | Repository webhooks (`Repository.spec.forProvider.webhooks`)             |
+
+## Organization permissions
+
+| Permission           | Access         | Why                                                          |
+| -------------------- | -------------- | ------------------------------------------------------------ |
+| Administration       | Read and write | Organization profile/description, Actions enabled-repos selection |
+| Members              | Read and write | `Membership` CR, `Team` CR (team CRUD + team membership)     |
+| Actions variables    | Read and write | `OrganizationVariable` CR                                    |
+| Secrets              | Read and write | `secrets.actionsSecrets` on the `Organization` CR (repo-access selection) |
+| Dependabot secrets   | Read and write | `secrets.dependabotSecrets` on the `Organization` CR (repo-access selection) |
+
+> **Note** — the provider does not create or update the secret values themselves;
+> it only manages which repositories are granted access to existing
+> organization-level secrets. The secret values are expected to be set out-of-band.
+
+## Per-resource breakdown
+
+If you run a least-privilege setup with multiple Apps, the table below maps
+each managed resource to the permissions its controller actually exercises.
+For pooled multi-App configurations (`ProviderConfig.spec.additionalCredentials`)
+the union of all listed permissions must be present on every App, since the
+provider picks an App per reconcile based on rate-limit headroom.
+
+| Managed resource       | Repository permissions                                | Organization permissions                                       |
+| ---------------------- | ----------------------------------------------------- | -------------------------------------------------------------- |
+| `Organization`         | Metadata (R)                                          | Administration (R/W), Secrets (R/W), Dependabot secrets (R/W)  |
+| `OrganizationVariable` | Metadata (R)                                          | Actions variables (R/W)                                        |
+| `Repository`           | Metadata (R), Contents (R), Administration (R/W), Webhooks (R/W) | Members (R) — for team-to-repo associations          |
+| `Team`                 | Administration (R/W) — for team-to-repo associations  | Members (R/W)                                                  |
+| `Membership`           | —                                                     | Members (R/W)                                                  |
+
+## Repository access scope
+
+When installing the App on the organization, grant it access to **All
+repositories** (or to the explicit subset you intend to manage). The
+provider does not request the App-installation token to be narrowed at
+runtime; it uses the installation token as issued.

--- a/README.md
+++ b/README.md
@@ -4,28 +4,39 @@
 that is meant to be used to manage github organizations.
 
 The project is in a prototyping phase but it's already functional and
-implements follwing objects with partial functionality:
+implements the following resources with partial functionality:
 
-* Organization
-  * actions enabled repositories
-  * actions and dependabot secrets repository access
+* **Organization** — manages an existing organization (creation and deletion are not supported)
   * description
-  * creation and deletion not supported
-* Team
-  * visibility
-  * description
-  * members
-  * parent team
-* Repository
-  * user permissions  
+  * Actions enabled repositories
+  * Actions secrets — repository access (secret values are set out-of-band)
+  * Dependabot secrets — repository access (secret values are set out-of-band)
+* **OrganizationVariable** — Actions variables at the organization level
+  * value
+  * visibility (`all`, `private`, `selected`)
+  * selected repositories
+* **Repository**
+  * description, visibility (private/public), topics, template flag
+  * creation from a template repository or as a fork
+  * user (collaborator) permissions
   * team permissions
   * webhooks
-  * branch protection rules
-  * Repository rules
-    * rulesets
-* Membership
+  * branch protection rules (including required status checks, required reviews, restrictions, signed commits)
+  * repository rulesets
+  * archive-on-delete safeguard
+* **Team**
+  * description
+  * visibility (`secret`, `closed`)
+  * members
+  * parent team
+* **Membership** — organization membership
   * role
 
+## GitHub App permissions
+
+See [PERMISSIONS.md](./PERMISSIONS.md) for the GitHub App permissions
+the provider requires, including a per-resource breakdown for
+least-privilege setups.
 
 ## Operational considerations
 


### PR DESCRIPTION
## Summary

- Refresh the README's resource list to match what the provider actually implements today (adds `OrganizationVariable`, the recently-merged Repository features, and a typo fix).
- Add `PERMISSIONS.md` documenting the GitHub App permissions the provider needs, both globally and broken down per managed resource.
- Link the new doc from the README.

## Why

The README's resource list dated from before `OrganizationVariable`, topics, template/fork-based repository creation, archived flag, and other recent features landed. It also had a typo ("follwing") and lacked any mention of which GitHub App permissions to grant when installing the provider. Operators had to either read the controllers or trial-and-error their way through the GitHub App configuration UI.

This PR is a pure documentation change — no code, no behavior, no API surface.

## What's in `PERMISSIONS.md`

Two tables (Repository and Organization permissions) listing every scope the provider exercises, with the access level (Read / Read & Write) and a one-liner on what the provider uses it for. A per-resource breakdown follows so anyone running a least-privilege or multi-App setup can see exactly which permissions each managed CR depends on. A short note at the end about repository access scope (typically "All repositories") closes out the doc.

The list reflects the actual call sites in `internal/controller/` — it's not aspirational. Notably:
- The provider does **not** create or update secret values; it only manages repository access on existing org-level secrets. The doc calls this out.
- `Contents: Read` is needed for `ListBranches` (used by branch-protection-rule reconciliation), not for any code-pulling operation.

## What's in the README refresh

- Resource list rewritten so every entry has a bold name + short one-line description of scope and edge cases (e.g. `Organization — manages an existing organization (creation and deletion are not supported)`).
- `OrganizationVariable` added (was missing).
- Repository entry now mentions: visibility, topics, template flag, template-based create, fork-based create, archive-on-delete.
- Branch-protection-rule line spelled out the sub-features (required status checks, required reviews, restrictions, signed commits).
- New `## GitHub App permissions` section linking to `PERMISSIONS.md`.

## Test plan

- [x] `make lint` passes (no code changes; docs only).
- [x] Markdown rendering verified locally — both tables in `PERMISSIONS.md` line up, and the README's internal link to `PERMISSIONS.md` resolves.
- [x] Resource list cross-checked against `apis/organizations/v1alpha1/` types so it doesn't claim anything the API doesn't support.
- [x] Permission entries cross-checked against the actual `gh.<Service>.<Method>` call sites under `internal/controller/`.
