### PR TITLE
Refactor listBranches to Protected=true with lazy existence check

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -97,6 +97,7 @@ type RepositoriesClient interface {
 	DeleteHook(ctx context.Context, owner, repo string, id int64) (*github.Response, error)
 	ListHooks(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.Hook, *github.Response, error)
 	ListBranches(ctx context.Context, owner, repo string, opts *github.BranchListOptions) ([]*github.Branch, *github.Response, error)
+	GetBranch(ctx context.Context, owner, repo, branch string, maxRedirects int) (*github.Branch, *github.Response, error)
 	GetBranchProtection(ctx context.Context, owner, repo, branch string) (*github.Protection, *github.Response, error)
 	UpdateBranchProtection(ctx context.Context, owner, repo, branch string, preq *github.ProtectionRequest) (*github.Protection, *github.Response, error)
 	RemoveBranchProtection(ctx context.Context, owner, repo, branch string) (*github.Response, error)

--- a/internal/clients/fake/client.go
+++ b/internal/clients/fake/client.go
@@ -140,6 +140,7 @@ type MockRepositoriesClient struct {
 	MockDeleteHook                          func(ctx context.Context, owner, repo string, id int64) (*github.Response, error)
 	MockListHooks                           func(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.Hook, *github.Response, error)
 	MockListBranches                        func(ctx context.Context, owner, repo string, opts *github.BranchListOptions) ([]*github.Branch, *github.Response, error)
+	MockGetBranch                           func(ctx context.Context, owner, repo, branch string, maxRedirects int) (*github.Branch, *github.Response, error)
 	MockGetBranchProtection                 func(ctx context.Context, owner, repo, branch string) (*github.Protection, *github.Response, error)
 	MockUpdateBranchProtection              func(ctx context.Context, owner, repo, branch string, preq *github.ProtectionRequest) (*github.Protection, *github.Response, error)
 	MockRemoveBranchProtection              func(ctx context.Context, owner, repo, branch string) (*github.Response, error)
@@ -211,6 +212,10 @@ func (m *MockRepositoriesClient) ListHooks(ctx context.Context, owner, repo stri
 
 func (m *MockRepositoriesClient) ListBranches(ctx context.Context, owner, repo string, opts *github.BranchListOptions) ([]*github.Branch, *github.Response, error) {
 	return m.MockListBranches(ctx, owner, repo, opts)
+}
+
+func (m *MockRepositoriesClient) GetBranch(ctx context.Context, owner, repo, branch string, maxRedirects int) (*github.Branch, *github.Response, error) {
+	return m.MockGetBranch(ctx, owner, repo, branch, maxRedirects)
 }
 
 func (m *MockRepositoriesClient) GetBranchProtection(ctx context.Context, owner, repo, branch string) (*github.Protection, *github.Response, error) {

--- a/internal/clients/rate_limit_client.go
+++ b/internal/clients/rate_limit_client.go
@@ -325,6 +325,12 @@ func (rrc *RateLimitRepositoriesClient) ListBranches(ctx context.Context, owner,
 	})
 }
 
+func (rrc *RateLimitRepositoriesClient) GetBranch(ctx context.Context, owner, repo, branch string, maxRedirects int) (*github.Branch, *github.Response, error) {
+	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.GetBranch", func() (*github.Branch, *github.Response, error) {
+		return rrc.RepositoriesClient.GetBranch(ctx, owner, repo, branch, maxRedirects)
+	})
+}
+
 func (rrc *RateLimitRepositoriesClient) GetBranchProtection(ctx context.Context, owner, repo, branch string) (*github.Protection, *github.Response, error) {
 	return recordRateLimit(ctx, rrc.metrics, rrc.org, rrc.appID, rrc.installationID, rrc.cacheKey, "Repositories.GetBranchProtection", func() (*github.Protection, *github.Response, error) {
 		return rrc.RepositoriesClient.GetBranchProtection(ctx, owner, repo, branch)

--- a/internal/controller/repository/repository.go
+++ b/internal/controller/repository/repository.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"reflect"
 	"sort"
 	"strings"
@@ -209,12 +210,15 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	if cr.Spec.ForProvider.BranchProtectionRules != nil {
-		protectedBranches, existingBranches, err := listBranches(ctx, c.github, cr.Spec.ForProvider.Org, name)
+		protectedBranches, err := listProtectedBranches(ctx, c.github, cr.Spec.ForProvider.Org, name)
 		if err != nil {
 			return managed.ExternalObservation{}, err
 		}
 		crBPRToConfig := getBPRMapFromCr(cr.Spec.ForProvider.BranchProtectionRules)
-		skipped := filterMissingBranchProtectionRules(crBPRToConfig, existingBranches)
+		skipped, err := filterMissingBranchProtectionRules(ctx, c.github, cr.Spec.ForProvider.Org, name, crBPRToConfig, protectedBranchSet(protectedBranches))
+		if err != nil {
+			return managed.ExternalObservation{}, err
+		}
 		setBranchProtectionPartialCondition(ctx, cr, skipped)
 		ghBPRToConfig, err := getBPRWithConfig(ctx, c.github, cr.Spec.ForProvider.Org, name, protectedBranches)
 		if err != nil {
@@ -585,55 +589,83 @@ func getRepoUsersWithPermissions(ctx context.Context, gh *ghclient.RateLimitClie
 	return uToPermission, nil
 }
 
-// listBranches lists all branches for a GitHub repository in a single
-// paginated call and returns both the protected subset and the set of all
-// branch names. Callers use the protected subset to fetch existing
-// protection configs, and the name set to filter out CR rules that point
-// at branches the repo doesn't have — preventing wasted 404 calls to
-// UpdateBranchProtection.
-func listBranches(ctx context.Context, gh *ghclient.RateLimitClient, org, repoName string) ([]*github.Branch, map[string]bool, error) {
+// listProtectedBranches returns every protected branch on a repo,
+// iterating pages. The Protected=true filter on GitHub keeps the
+// page count tiny (typically 1 page) regardless of how many feature
+// branches the repo has, so per-Observe pagination cost stays
+// constant even on monorepos with thousands of branches.
+func listProtectedBranches(ctx context.Context, gh *ghclient.RateLimitClient, org, repoName string) ([]*github.Branch, error) {
 	opts := &github.BranchListOptions{
+		Protected:   github.Bool(true),
 		ListOptions: github.ListOptions{PerPage: 100},
 	}
-	var allBranches []*github.Branch
-
+	var protected []*github.Branch
 	for {
 		branches, resp, err := gh.Repositories.ListBranches(ctx, org, repoName, opts)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
-		allBranches = append(allBranches, branches...)
-
+		protected = append(protected, branches...)
 		if resp.NextPage == 0 {
 			break
 		}
 		opts.Page = resp.NextPage
 	}
-
-	existing := make(map[string]bool, len(allBranches))
-	var protected []*github.Branch
-	for _, b := range allBranches {
-		existing[b.GetName()] = true
-		if b.GetProtected() {
-			protected = append(protected, b)
-		}
-	}
-	return protected, existing, nil
+	return protected, nil
 }
 
+// 1 hop covers a single branch rename; deeper chains aren't worth chasing.
+const branchRenameRedirectsToFollow = 1
+
 // filterMissingBranchProtectionRules removes entries from rules whose
-// branch is not present in existing. Returns the sorted list of skipped
-// branch names so callers can log and emit an Event. Mutates rules.
-func filterMissingBranchProtectionRules(rules map[string]v1alpha1.BranchProtectionRule, existing map[string]bool) []string {
+// target branch doesn't exist in the repo. Returns the sorted list of
+// skipped branch names so callers can log and emit an Event. Mutates
+// rules.
+//
+// Branches already in protectedSet exist by construction (you cannot
+// protect a branch that doesn't exist), so they're accepted without
+// any extra API call. The rest are confirmed with a per-branch
+// Repositories.GetBranch — 404 means the branch is missing and the
+// rule is dropped; a redirect to a different name means the branch
+// was renamed (mutating endpoints don't follow redirects, so the rule
+// can't apply against the old name) and the skipped entry carries the
+// new name so the operator can update the CR; any other error
+// propagates.
+func filterMissingBranchProtectionRules(ctx context.Context, gh *ghclient.RateLimitClient, org, repoName string, rules map[string]v1alpha1.BranchProtectionRule, protectedSet map[string]bool) ([]string, error) {
 	var skipped []string
 	for branch := range rules {
-		if !existing[branch] {
+		if protectedSet[branch] {
+			continue
+		}
+		// GetBranch reports non-200 with a bare fmt.Errorf, so check resp.StatusCode rather than Is404(err).
+		got, resp, err := gh.Repositories.GetBranch(ctx, org, repoName, branch, branchRenameRedirectsToFollow)
+		if err == nil {
+			if got != nil && got.GetName() != branch {
+				skipped = append(skipped, fmt.Sprintf("%s (was renamed to %s)", branch, got.GetName()))
+				delete(rules, branch)
+			}
+			continue
+		}
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			skipped = append(skipped, branch)
 			delete(rules, branch)
+			continue
 		}
+		return nil, err
 	}
 	sort.Strings(skipped)
-	return skipped
+	return skipped, nil
+}
+
+// protectedBranchSet returns the set of branch names from a list of
+// protected branches, for fast "is this branch already protected?"
+// lookup in filterMissingBranchProtectionRules.
+func protectedBranchSet(branches []*github.Branch) map[string]bool {
+	set := make(map[string]bool, len(branches))
+	for _, b := range branches {
+		set[b.GetName()] = true
+	}
+	return set
 }
 
 // Condition surfaced on the Repository CR when one or more declared
@@ -981,13 +1013,16 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	if cr.Spec.ForProvider.BranchProtectionRules != nil {
-		_, existingBranches, err := listBranches(ctx, c.github, cr.Spec.ForProvider.Org, name)
+		protectedBranches, err := listProtectedBranches(ctx, c.github, cr.Spec.ForProvider.Org, name)
 		if err != nil {
 			return managed.ExternalCreation{}, err
 		}
 		// getBPRMapFromCr() provides defaults for optional *bool fields
 		rulesMap := getBPRMapFromCr(cr.Spec.ForProvider.BranchProtectionRules)
-		skipped := filterMissingBranchProtectionRules(rulesMap, existingBranches)
+		skipped, err := filterMissingBranchProtectionRules(ctx, c.github, cr.Spec.ForProvider.Org, name, rulesMap, protectedBranchSet(protectedBranches))
+		if err != nil {
+			return managed.ExternalCreation{}, err
+		}
 		setBranchProtectionPartialCondition(ctx, cr, skipped)
 		for key := range rulesMap {
 			// avoid "G601: Implicit memory aliasing in for loop"
@@ -1268,12 +1303,15 @@ func editProtectedBranch(ctx context.Context, rule *v1alpha1.BranchProtectionRul
 // It performs necessary additions, updates, or deletions based on the difference between
 // the actual state on GitHub and the desired state in the resource object.
 func updateProtectedBranches(ctx context.Context, cr *v1alpha1.Repository, gh *ghclient.RateLimitClient, repoName string) error {
-	protectedBranches, existingBranches, err := listBranches(ctx, gh, cr.Spec.ForProvider.Org, repoName)
+	protectedBranches, err := listProtectedBranches(ctx, gh, cr.Spec.ForProvider.Org, repoName)
 	if err != nil {
 		return err
 	}
 	crBPRToConfig := getBPRMapFromCr(cr.Spec.ForProvider.BranchProtectionRules)
-	skipped := filterMissingBranchProtectionRules(crBPRToConfig, existingBranches)
+	skipped, err := filterMissingBranchProtectionRules(ctx, gh, cr.Spec.ForProvider.Org, repoName, crBPRToConfig, protectedBranchSet(protectedBranches))
+	if err != nil {
+		return err
+	}
 	setBranchProtectionPartialCondition(ctx, cr, skipped)
 	ghBPRToConfig, err := getBPRWithConfig(ctx, gh, cr.Spec.ForProvider.Org, repoName, protectedBranches)
 	if err != nil {

--- a/internal/controller/repository/repository_test.go
+++ b/internal/controller/repository/repository_test.go
@@ -18,6 +18,10 @@ package repository
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
 	"strings"
 	"testing"
 
@@ -646,62 +650,179 @@ func TestObserve(t *testing.T) {
 // rules for missing branches are removed from the map, rules for existing
 // branches are kept untouched, and the skipped list is returned sorted so
 // the condition message is stable across reconciles.
+// filterMissingBranchProtectionRules has two responsibilities:
+//
+//   - Short-circuit branches already in protectedSet without calling
+//     GetBranch (they exist by construction — you can't protect a
+//     missing branch).
+//   - For the rest, hit Repositories.GetBranch: 404 means the branch
+//     is missing and the rule is dropped; 2xx means the branch exists
+//     but is unprotected (the rule will be applied by Update); any
+//     other error propagates.
+//
+// The wantCalls assertion pins the short-circuit — if a future change
+// stops respecting protectedSet, every reconcile would emit an extra
+// GetBranch per already-protected branch, which is the whole API-cost
+// reason the protectedSet path exists.
 func TestFilterMissingBranchProtectionRules(t *testing.T) {
+	ctx := context.Background()
+	const org = "test-org"
+	const repo = "test-repo"
+
+	type mockBranches struct {
+		exists  map[string]bool   // GetBranch returns 200 with name == requested
+		missing map[string]bool   // GetBranch returns 404
+		renamed map[string]string // GetBranch returns 200 but with a different name (key → value mapping)
+		errFor  string            // GetBranch returns a non-404 error for this branch
+	}
+
 	cases := map[string]struct {
-		rules       map[string]v1alpha1.BranchProtectionRule
-		existing    map[string]bool
-		wantRules   map[string]v1alpha1.BranchProtectionRule
-		wantSkipped []string
+		rules        map[string]v1alpha1.BranchProtectionRule
+		protectedSet map[string]bool
+		mock         mockBranches
+		wantRules    map[string]v1alpha1.BranchProtectionRule
+		wantSkipped  []string
+		wantCalls    []string
+		wantErr      bool
 	}{
-		"AllBranchesExist_NothingFiltered": {
+		"AllAlreadyProtected_NoGetBranchCalls": {
 			rules: map[string]v1alpha1.BranchProtectionRule{
 				"main":    {Branch: "main"},
 				"develop": {Branch: "develop"},
 			},
-			existing: map[string]bool{"main": true, "develop": true},
+			protectedSet: map[string]bool{"main": true, "develop": true},
 			wantRules: map[string]v1alpha1.BranchProtectionRule{
 				"main":    {Branch: "main"},
 				"develop": {Branch: "develop"},
 			},
 			wantSkipped: nil,
+			wantCalls:   nil,
 		},
-		"SomeMissing_FilteredAndReturnedSorted": {
+		"UnprotectedButExisting_CheckedAndKept": {
+			rules: map[string]v1alpha1.BranchProtectionRule{
+				"main":    {Branch: "main"},
+				"develop": {Branch: "develop"},
+			},
+			protectedSet: map[string]bool{"main": true},
+			mock:         mockBranches{exists: map[string]bool{"develop": true}},
+			wantRules: map[string]v1alpha1.BranchProtectionRule{
+				"main":    {Branch: "main"},
+				"develop": {Branch: "develop"},
+			},
+			wantSkipped: nil,
+			wantCalls:   []string{"develop"},
+		},
+		"MissingBranches_Skipped": {
 			rules: map[string]v1alpha1.BranchProtectionRule{
 				"main":    {Branch: "main"},
 				"release": {Branch: "release"},
-				"develop": {Branch: "develop"},
+				"ghost":   {Branch: "ghost"},
 			},
-			existing: map[string]bool{"main": true},
-			wantRules: map[string]v1alpha1.BranchProtectionRule{
-				"main": {Branch: "main"},
+			protectedSet: map[string]bool{"main": true},
+			mock: mockBranches{
+				missing: map[string]bool{"release": true, "ghost": true},
 			},
-			wantSkipped: []string{"develop", "release"},
+			wantRules:   map[string]v1alpha1.BranchProtectionRule{"main": {Branch: "main"}},
+			wantSkipped: []string{"ghost", "release"},
+			wantCalls:   []string{"ghost", "release"},
 		},
-		"AllMissing_MapEmptied": {
+		"MixedExistingAndMissing": {
 			rules: map[string]v1alpha1.BranchProtectionRule{
+				"main":    {Branch: "main"},
 				"develop": {Branch: "develop"},
-				"release": {Branch: "release"},
+				"ghost":   {Branch: "ghost"},
 			},
-			existing:    map[string]bool{},
-			wantRules:   map[string]v1alpha1.BranchProtectionRule{},
-			wantSkipped: []string{"develop", "release"},
+			protectedSet: map[string]bool{"main": true},
+			mock: mockBranches{
+				exists:  map[string]bool{"develop": true},
+				missing: map[string]bool{"ghost": true},
+			},
+			wantRules: map[string]v1alpha1.BranchProtectionRule{
+				"main":    {Branch: "main"},
+				"develop": {Branch: "develop"},
+			},
+			wantSkipped: []string{"ghost"},
+			wantCalls:   []string{"develop", "ghost"},
 		},
-		"EmptyInput_NoChange": {
-			rules:       map[string]v1alpha1.BranchProtectionRule{},
-			existing:    map[string]bool{"main": true},
-			wantRules:   map[string]v1alpha1.BranchProtectionRule{},
-			wantSkipped: nil,
+		"EmptyInput_NoCallsNoSkipped": {
+			rules:        map[string]v1alpha1.BranchProtectionRule{},
+			protectedSet: map[string]bool{"main": true},
+			wantRules:    map[string]v1alpha1.BranchProtectionRule{},
+			wantSkipped:  nil,
+			wantCalls:    nil,
+		},
+		"Non404Error_Propagates": {
+			rules:        map[string]v1alpha1.BranchProtectionRule{"feature": {Branch: "feature"}},
+			protectedSet: map[string]bool{},
+			mock:         mockBranches{errFor: "feature"},
+			wantErr:      true,
+		},
+		// Renamed branches must not be silently accepted as existing — the rule
+		// will 404 on the actual UpdateBranchProtection call because PUT doesn't
+		// follow the rename redirect. Surface the new name in the skipped entry
+		// so the operator knows what to put in the CR.
+		"RenamedBranch_DroppedAndNameSurfaced": {
+			rules: map[string]v1alpha1.BranchProtectionRule{
+				"main":    {Branch: "main"},
+				"develop": {Branch: "develop"},
+			},
+			protectedSet: map[string]bool{},
+			mock: mockBranches{
+				renamed: map[string]string{"main": "trunk"},
+				exists:  map[string]bool{"develop": true},
+			},
+			wantRules:   map[string]v1alpha1.BranchProtectionRule{"develop": {Branch: "develop"}},
+			wantSkipped: []string{"main (was renamed to trunk)"},
+			wantCalls:   []string{"develop", "main"},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			gotSkipped := filterMissingBranchProtectionRules(tc.rules, tc.existing)
+			var calls []string
+			gh := &ghclient.RateLimitClient{
+				Client: &ghclient.Client{
+					Repositories: &fake.MockRepositoriesClient{
+						MockGetBranch: func(_ context.Context, _, _, branch string, _ int) (*github.Branch, *github.Response, error) {
+							calls = append(calls, branch)
+							switch {
+							case branch == tc.mock.errFor:
+								return nil, &github.Response{Response: &http.Response{StatusCode: http.StatusInternalServerError}}, errors.New("boom")
+							case tc.mock.missing[branch]:
+								// Real GetBranch returns a bare fmt.Errorf + non-nil resp.StatusCode=404, not a *github.ErrorResponse.
+								return nil, &github.Response{Response: &http.Response{StatusCode: http.StatusNotFound}}, fmt.Errorf("unexpected status code: 404 Not Found")
+							case tc.mock.renamed[branch] != "":
+								// 200 with a different name — GetBranch followed a rename redirect.
+								return &github.Branch{Name: github.String(tc.mock.renamed[branch])}, fake.GenerateEmptyResponse(), nil
+							case tc.mock.exists[branch]:
+								return &github.Branch{Name: github.String(branch)}, fake.GenerateEmptyResponse(), nil
+							default:
+								return nil, nil, errors.New("unexpected branch in mock: " + branch)
+							}
+						},
+					},
+				},
+			}
+
+			gotSkipped, err := filterMissingBranchProtectionRules(ctx, gh, org, repo, tc.rules, tc.protectedSet)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if diff := cmp.Diff(tc.wantSkipped, gotSkipped); diff != "" {
 				t.Errorf("skipped: -want, +got:\n%s", diff)
 			}
 			if diff := cmp.Diff(tc.wantRules, tc.rules); diff != "" {
 				t.Errorf("rules after filter: -want, +got:\n%s", diff)
+			}
+			sort.Strings(calls)
+			if diff := cmp.Diff(tc.wantCalls, calls); diff != "" {
+				t.Errorf("GetBranch calls: -want, +got:\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Replace the "list every branch in the repo" approach (added in PR #42 for graceful BPR handling) with `Repositories.ListBranches?protected=true` + a lazy `Repositories.GetBranch` existence check.
- Pagination cost on the BPR sub-path goes from O(total branches in repo / 100) to O(1) regardless of branch count; per-`Observe` `GetBranch` cost is O(0) in steady state because already-protected branches are accepted without a per-branch lookup.
- Renamed branches now surface in the `BranchProtectionPartial` condition with the new name in the message (e.g. `branches do not exist in repo: main (was renamed to trunk)`), instead of silently 404-ing the next `UpdateBranchProtection` call.

## Problem

PR #42 introduced graceful handling for `BranchProtectionRule` entries whose target branch doesn't exist in the repo. It correctly skips those rules and surfaces them via a `BranchProtectionPartial` status condition. The implementation reached this by paginating the *entire* branch list (no filter) and checking CR-declared BPRs against it.

For monorepos with thousands of feature branches, that pagination cost dominated a single `Observe`: the BPR sub-path alone could spend more time walking `ListBranches` pages than every other read in the controller combined, and the largest repos hit the reconcile timeout before any BPR-config-check work could run.

## What changes

`internal/controller/repository/repository.go`:

- `listProtectedBranches` replaces the old "list everything" walk. The `Protected=true` filter keeps the result tiny (typically one page per repo, because most repos protect a handful of branches at most).
- `filterMissingBranchProtectionRules` accepts the set of protected branch names and, for each CR-declared BPR not already in that set, makes a single `Repositories.GetBranch` call:
  - Returns the same name → branch exists; keep the rule.
  - Returns a *different* name → branch was renamed; drop the rule and add `"<old> (was renamed to <new>)"` to the skipped set.
  - Returns 404 → branch doesn't exist; drop the rule and add the name to the skipped set.
  - Any other error propagates.
- The skipped set drives the existing `BranchProtectionPartial` condition messaging unchanged. The renamed-branch case piggybacks on the same path so operators see a single condition with all the information they need to fix the spec.

Three small client changes:

- `Repositories.GetBranch` added to the `RepositoriesClient` interface (the only API method used here that wasn't already wrapped).
- Rate-limit-aware wrapper in `RateLimitRepositoriesClient`.
- Mock in `internal/clients/fake`.

## Why `maxRedirects=1`

GitHub keeps a redirect alias for renamed branches (`GET /branches/{old}` → 301 → `GET /branches/{new}`). With `maxRedirects=1` the client follows that single hop and returns the *new* branch's data in the response. The filter uses the name-comparison to detect the rename rather than treating the 200 as confirmation of existence — mutating endpoints (`UpdateBranchProtection`) don't follow the redirect, so the rule has to drop either way; surfacing the new name to the operator is the value-add. Deeper rename chains aren't worth chasing.

## Test plan

- [x] **Unit tests** — `TestFilterMissingBranchProtectionRules` rewritten with table-driven cases covering: already-protected short-circuit (no `GetBranch` calls), unprotected-but-exists (kept), missing (404, dropped + surfaced), renamed (different returned name, dropped + new-name surfaced), mixed, empty input, non-404 error propagation. The mock now returns the real production error shape (bare `fmt.Errorf` with non-nil `*github.Response`), not the prior `*github.ErrorResponse` shape that hid a 404-detection bug during early development.
- [x] **End-to-end scale test in a kind cluster against a real GitHub test org**, with a Repository CR backed by a repo of ~100+ branches:
  - Steady-state Observe per reconcile: `ListBranches=1`, `GetBranch=0`, regardless of total branch count.
  - Add BPR for an existing-but-unprotected branch → one `GetBranch` (200) + one `UpdateBranchProtection` → next reconcile silent.
  - Add BPR for a non-existent branch → one `GetBranch` (404) → rule dropped → `BranchProtectionPartial=True (BranchesMissing) — branches do not exist in repo: <name>`.
  - Remove a BPR from the CR → `RemoveBranchProtection` fires once.
  - External drift (manual un-protect via GitHub UI) → next reconcile re-applies via `UpdateBranchProtection`.
  - Rename a protected branch on GitHub via the rename API → `BranchProtectionPartial=True` with `branches do not exist in repo: <old> (was renamed to <new>)`; no spurious `UpdateBranchProtection` errors.

## Notes

- The 404-detection mechanism uses `resp.StatusCode == http.StatusNotFound` directly because `Repositories.GetBranch` is one of the go-github methods that goes through `roundTripWithOptionalFollowRedirect` and reports non-200 status via a bare `fmt.Errorf` (not a `*github.ErrorResponse`), so the existing `ghclient.Is404(err)` helper doesn't match. Other go-github methods using that same redirect-following pattern (`GetContents`, the workflow-job/workflow-run endpoints) have the same quirk; if we ever wrap those, the same direct-status check applies.
- No new dependencies, no public API changes outside the internal `RepositoriesClient` interface.
