### PR TITLE
Remove unused telemetry helpers and duplicate NewClient

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -19,11 +19,7 @@ package clients
 import (
 	"context"
 	"errors"
-	"net/http"
-	"strconv"
-	"strings"
 
-	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/v62/github"
 )
 
@@ -108,40 +104,6 @@ type RepositoriesClient interface {
 	UpdateRuleset(ctx context.Context, owner, repo string, rulesetID int64, ruleset *github.Ruleset) (*github.Ruleset, *github.Response, error)
 	DeleteRuleset(ctx context.Context, owner, repo string, rulesetID int64) (*github.Response, error)
 	ReplaceAllTopics(ctx context.Context, owner, repo string, topics []string) ([]string, *github.Response, error)
-}
-
-// NewClient creates a new client.
-func NewClient(creds string) (*Client, error) {
-	credss := strings.Split(creds, ",")
-	if len(credss) != 3 {
-		return nil, errors.New("invalid format for credentials")
-	}
-
-	appId, err := strconv.Atoi(credss[0])
-	if err != nil {
-		return nil, err
-	}
-
-	installationId, err := strconv.Atoi(credss[1])
-	if err != nil {
-		return nil, err
-	}
-
-	itr, err := ghinstallation.New(http.DefaultTransport, int64(appId), int64(installationId), []byte(credss[2]))
-	if err != nil {
-		return nil, err
-	}
-
-	ghclient := github.NewClient(&http.Client{Transport: itr})
-
-	return &Client{
-		Actions:       ghclient.Actions,
-		Dependabot:    ghclient.Dependabot,
-		Organizations: ghclient.Organizations,
-		Users:         ghclient.Users,
-		Teams:         ghclient.Teams,
-		Repositories:  ghclient.Repositories,
-	}, nil
 }
 
 func Is404(err error) bool {

--- a/internal/telemetry/rate_limit.go
+++ b/internal/telemetry/rate_limit.go
@@ -17,9 +17,7 @@ limitations under the License.
 package telemetry
 
 import (
-	"errors"
 	"net/http"
-	"time"
 
 	"github.com/google/go-github/v62/github"
 	"github.com/prometheus/client_golang/prometheus"
@@ -209,42 +207,4 @@ func (m *RateLimitMetrics) RecordRateLimitInfo(resp *github.Response, org, appID
 		m.rateLimitRemaining.WithLabelValues(org, appID, installationID).Set(float64(resp.Rate.Remaining))
 		m.rateLimitResetTime.WithLabelValues(org, appID, installationID).Set(float64(resp.Rate.Reset.Unix()))
 	}
-}
-
-// IsRateLimited checks if the error is due to rate limiting
-func IsRateLimited(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	var errResp *github.ErrorResponse
-	if errors.As(err, &errResp) {
-		return errResp.Response.StatusCode == http.StatusTooManyRequests
-	}
-
-	return false
-}
-
-// GetRateLimitInfo extracts rate limit information from GitHub response
-func GetRateLimitInfo(resp *github.Response) (limit, remaining int, resetTime time.Time) {
-	if resp == nil {
-		return 0, 0, time.Time{}
-	}
-
-	return resp.Rate.Limit, resp.Rate.Remaining, resp.Rate.Reset.Time
-}
-
-// IsRateLimitExceeded checks if the response indicates rate limit exceeded
-func IsRateLimitExceeded(resp *github.Response) bool {
-	return resp != nil && resp.StatusCode == 429
-}
-
-// GetRateLimitUsagePercentage calculates the percentage of rate limit used
-func GetRateLimitUsagePercentage(resp *github.Response) float64 {
-	if resp == nil || resp.Rate.Limit == 0 {
-		return 0
-	}
-
-	used := resp.Rate.Limit - resp.Rate.Remaining
-	return float64(used) / float64(resp.Rate.Limit) * 100
 }


### PR DESCRIPTION
## Summary

Removes two pieces of dead code surfaced while reviewing the BPR refactor:

- Four unused helpers in `internal/telemetry/rate_limit.go` (`IsRateLimited`, `GetRateLimitInfo`, `IsRateLimitExceeded`, `GetRateLimitUsagePercentage`).
- The package-level `NewClient` in `internal/clients/client.go`, which was a verbatim duplicate of `createNewClient` in `cached_client.go`.

No behavior change. Pure cleanup, kept on its own branch so the BPR change set stays focused.

## What changes

`internal/telemetry/rate_limit.go`

The four helpers had zero callers anywhere in the repo (production or test). They appear to be stubs from an earlier API shape that was superseded by the `Record*` methods invoked from `recordResponse` in `internal/clients/rate_limit_client.go`. Removing them also drops the `errors` and `time` imports they were the sole users of.

`internal/clients/client.go`

`NewClient` was an exact line-for-line copy of `createNewClient` in `cached_client.go`. Every production caller and every test reaches construction through `NewCachedClient`, which delegates to `createNewClient`. Removing `NewClient` also drops the `strings`, `strconv`, `net/http`, and `bradleyfalzon/ghinstallation/v2` imports it was the sole user of in this file.

## Verification

- `deadcode -test ./...` reports no unreachable funcs after the deletions (it reported the two items above before).
- `go build ./...` clean.
- `go test ./...` → 92 passed in 17 packages.
- Independent of the in-flight BPR refactor: cherry-picking this commit onto that branch auto-merges cleanly and the combined tree still builds and passes all tests.

## Notes

- Test-only helpers that `deadcode` flags without `-test` (`quotaPool.snapshot`, `telemetry.NewForTest`, the `fake.Mock*` methods, `fake.Generate404Response`, `fake.GenerateEmptyResponse`) are intentionally kept — they all have callers under `*_test.go`.
- No public API surface change. `internal/...` packages have no external consumers.
