### PR TITLE
Periodically heartbeat GitHub App installations to avoid idle rate-limit demotion

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -62,6 +62,7 @@ func main() {
 		enableExternalSecretStores = app.Flag("enable-external-secret-stores", "Enable support for ExternalSecretStores.").Default("false").Envar("ENABLE_EXTERNAL_SECRET_STORES").Bool()
 		enableManagementPolicies   = app.Flag("enable-management-policies", "Enable support for Management Policies.").Default("false").Envar("ENABLE_MANAGEMENT_POLICIES").Bool()
 		customMetricsAddr          = app.Flag("custom-metrics-addr", "The address the custom metric endpoint binds to.").Default(":8081").String()
+		heartbeatInterval          = app.Flag("heartbeat-interval", "How often each GitHub App installation is pinged to keep it on the high rate-limit tier.").Default("10m").Envar("HEARTBEAT_INTERVAL").Duration()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
@@ -162,5 +163,8 @@ func main() {
 		}
 	}()
 
-	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
+	signalCtx := ctrl.SetupSignalHandler()
+	go ghclient.HeartbeatApps(signalCtx, metrics, *heartbeatInterval)
+
+	kingpin.FatalIfError(mgr.Start(signalCtx), "Cannot start controller manager")
 }

--- a/internal/clients/cached_client.go
+++ b/internal/clients/cached_client.go
@@ -41,9 +41,12 @@ type ClientCache struct {
 }
 
 type cachedClientEntry struct {
-	client    *Client
-	createdAt time.Time
-	cacheKey  string
+	client          *Client
+	createdAt       time.Time
+	cacheKey        string
+	appID           string
+	installationID  string
+	installationOrg string
 }
 
 var (
@@ -62,8 +65,8 @@ func GenerateCacheKey(creds string) string {
 	return fmt.Sprintf("%x", hash[:8]) // Use first 8 bytes of hash
 }
 
-// NewCachedClient creates a new cached GitHub client that reuses tokens
-func NewCachedClient(creds string) (*Client, error) {
+// NewCachedClient creates a new cached GitHub client that reuses tokens.
+func NewCachedClient(creds, org string) (*Client, error) {
 	cacheKey := GenerateCacheKey(creds)
 
 	globalClientCache.mu.Lock()
@@ -85,11 +88,14 @@ func NewCachedClient(creds string) (*Client, error) {
 		return nil, err
 	}
 
-	// Cache the new client
+	appID, installationID, _ := ExtractAppIDs(creds)
 	globalClientCache.clients[cacheKey] = &cachedClientEntry{
-		client:    client,
-		createdAt: time.Now(),
-		cacheKey:  cacheKey,
+		client:          client,
+		createdAt:       time.Now(),
+		cacheKey:        cacheKey,
+		appID:           appID,
+		installationID:  installationID,
+		installationOrg: org,
 	}
 
 	return client, nil
@@ -135,12 +141,47 @@ func createNewClient(creds string) (*Client, error) {
 
 	return &Client{
 		Actions:       ghclient.Actions,
+		Apps:          ghclient.Apps,
 		Dependabot:    ghclient.Dependabot,
 		Organizations: ghclient.Organizations,
 		Users:         ghclient.Users,
 		Teams:         ghclient.Teams,
 		Repositories:  ghclient.Repositories,
 	}, nil
+}
+
+// SnapshotCacheKeys returns the cache keys currently held (including expired ones; pair with Lookup).
+func (c *ClientCache) SnapshotCacheKeys() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	keys := make([]string, 0, len(c.clients))
+	for k := range c.clients {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// Lookup returns the cached client for key, or (nil, false) if missing or expired.
+func (c *ClientCache) Lookup(key string) (*Client, bool) {
+	e, ok := c.LookupEntry(key)
+	if !ok {
+		return nil, false
+	}
+	return e.client, true
+}
+
+// LookupEntry returns the cached entry for key, or (nil, false) if missing or expired.
+func (c *ClientCache) LookupEntry(key string) (*cachedClientEntry, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, ok := c.clients[key]
+	if !ok {
+		return nil, false
+	}
+	if time.Since(entry.createdAt) >= clientCacheTimeout {
+		return nil, false
+	}
+	return entry, true
 }
 
 // CleanupExpiredClients removes expired clients from cache (optional background cleanup)

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -25,11 +25,16 @@ import (
 
 type Client struct {
 	Actions       ActionsClient
+	Apps          AppsClient
 	Dependabot    DependabotClient
 	Organizations OrganizationsClient
 	Users         UsersClient
 	Teams         TeamsClient
 	Repositories  RepositoriesClient
+}
+
+type AppsClient interface {
+	ListRepos(ctx context.Context, opts *github.ListOptions) (*github.ListRepositories, *github.Response, error)
 }
 
 type ActionsClient interface {

--- a/internal/clients/connect.go
+++ b/internal/clients/connect.go
@@ -82,7 +82,7 @@ func ResolveAndConnect(ctx context.Context, kube client.Client, pc *apisv1alpha1
 		metrics.RecordPickerPick(org, appID, installationID, pickReason)
 	}
 
-	gh, err := NewCachedClient(chosen)
+	gh, err := NewCachedClient(chosen, org)
 	if err != nil {
 		// Treat construction failures (non-numeric IDs, malformed PEM,
 		// etc.) the same way as token-mint failures: record on the pool

--- a/internal/clients/fake/client.go
+++ b/internal/clients/fake/client.go
@@ -65,6 +65,14 @@ func (m *MockActionsClient) SetSelectedReposForOrgVariable(ctx context.Context, 
 	return m.MockSetSelectedReposForOrgVariable(ctx, org, name, ids)
 }
 
+type MockAppsClient struct {
+	MockListRepos func(ctx context.Context, opts *github.ListOptions) (*github.ListRepositories, *github.Response, error)
+}
+
+func (m *MockAppsClient) ListRepos(ctx context.Context, opts *github.ListOptions) (*github.ListRepositories, *github.Response, error) {
+	return m.MockListRepos(ctx, opts)
+}
+
 type MockDependabotClient struct {
 	MockGetOrgSecret                  func(ctx context.Context, org, name string) (*github.Secret, *github.Response, error)
 	MockListSelectedReposForOrgSecret func(ctx context.Context, org, name string, opts *github.ListOptions) (*github.SelectedReposList, *github.Response, error)

--- a/internal/clients/heartbeat.go
+++ b/internal/clients/heartbeat.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package clients
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/go-github/v62/github"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/crossplane/provider-github/internal/telemetry"
+)
+
+// HeartbeatApps periodically pings each GitHub App installation to keep it on the high rate-limit tier.
+func HeartbeatApps(ctx context.Context, metrics *telemetry.RateLimitMetrics, interval time.Duration) {
+	heartbeatLoop(ctx, globalClientCache, globalPool, metrics, interval)
+}
+
+func heartbeatLoop(ctx context.Context, cache *ClientCache, pool *quotaPool, metrics *telemetry.RateLimitMetrics, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	heartbeatOnce(ctx, cache, pool, metrics)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			heartbeatOnce(ctx, cache, pool, metrics)
+		}
+	}
+}
+
+func heartbeatOnce(ctx context.Context, cache *ClientCache, pool *quotaPool, metrics *telemetry.RateLimitMetrics) {
+	log := ctrl.LoggerFrom(ctx).WithName("app-heartbeat")
+	now := pool.now()
+
+	for _, key := range cache.SnapshotCacheKeys() {
+		if snap := pool.snapshot(key); !snap.CooldownUntil.IsZero() && now.Before(snap.CooldownUntil) {
+			continue
+		}
+		entry, ok := cache.LookupEntry(key)
+		if !ok {
+			continue
+		}
+		_, resp, err := entry.client.Apps.ListRepos(ctx, &github.ListOptions{PerPage: 1})
+		pool.recordResponse(key, resp, err)
+		if metrics != nil {
+			metrics.RecordAppHeartbeat(entry.installationOrg, entry.appID, entry.installationID)
+			metrics.RecordRateLimitInfo(resp, entry.installationOrg, entry.appID, entry.installationID)
+			if err != nil {
+				metrics.RecordAppHeartbeatError(entry.installationOrg, entry.appID, entry.installationID)
+			}
+		}
+		if err != nil {
+			log.V(1).Info("heartbeat ping failed", "cacheKey", key, "err", err.Error())
+		}
+	}
+}

--- a/internal/clients/heartbeat_test.go
+++ b/internal/clients/heartbeat_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package clients
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v62/github"
+
+	"github.com/crossplane/provider-github/internal/clients/fake"
+)
+
+// newHeartbeatTestCache returns an isolated *ClientCache pre-populated from entries.
+func newHeartbeatTestCache(entries map[string]*fake.MockAppsClient) *ClientCache {
+	c := &ClientCache{clients: make(map[string]*cachedClientEntry)}
+	for key, mock := range entries {
+		c.clients[key] = &cachedClientEntry{
+			client:    &Client{Apps: mock},
+			createdAt: time.Now(),
+			cacheKey:  key,
+		}
+	}
+	return c
+}
+
+func TestHeartbeatOnce_PingsEachCachedApp(t *testing.T) {
+	now := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	pool := newQuotaPool(fixedNow(now))
+
+	calls := map[string]int{}
+	makeMock := func(key string) *fake.MockAppsClient {
+		return &fake.MockAppsClient{
+			MockListRepos: func(ctx context.Context, opts *github.ListOptions) (*github.ListRepositories, *github.Response, error) {
+				calls[key]++
+				return &github.ListRepositories{}, &github.Response{
+					Response: &http.Response{StatusCode: 200},
+					Rate:     github.Rate{Limit: 12500, Remaining: 12499, Reset: github.Timestamp{Time: now.Add(time.Hour)}},
+				}, nil
+			},
+		}
+	}
+	cache := newHeartbeatTestCache(map[string]*fake.MockAppsClient{
+		"app-A": makeMock("app-A"),
+		"app-B": makeMock("app-B"),
+		"app-C": makeMock("app-C"),
+	})
+
+	heartbeatOnce(context.Background(), cache, pool, nil)
+
+	for _, key := range []string{"app-A", "app-B", "app-C"} {
+		if calls[key] != 1 {
+			t.Errorf("Apps.ListRepos for %s called %d times, want 1", key, calls[key])
+		}
+	}
+}
+
+func TestHeartbeatOnce_SkipsAppInCooldown(t *testing.T) {
+	now := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	pool := newQuotaPool(fixedNow(now))
+
+	// Put app-cool into a future cooldown; heartbeatOnce must skip it.
+	pool.recordResponse("app-cool", &github.Response{
+		Response: &http.Response{StatusCode: http.StatusTooManyRequests},
+		Rate:     github.Rate{Reset: github.Timestamp{Time: now.Add(5 * time.Minute)}},
+	}, nil)
+
+	hotCalls, coolCalls := 0, 0
+	cache := newHeartbeatTestCache(map[string]*fake.MockAppsClient{
+		"app-hot": {
+			MockListRepos: func(ctx context.Context, opts *github.ListOptions) (*github.ListRepositories, *github.Response, error) {
+				hotCalls++
+				return &github.ListRepositories{}, &github.Response{Response: &http.Response{StatusCode: 200}}, nil
+			},
+		},
+		"app-cool": {
+			MockListRepos: func(ctx context.Context, opts *github.ListOptions) (*github.ListRepositories, *github.Response, error) {
+				coolCalls++
+				return nil, nil, nil
+			},
+		},
+	})
+
+	heartbeatOnce(context.Background(), cache, pool, nil)
+
+	if hotCalls != 1 {
+		t.Errorf("app-hot Apps.ListRepos called %d times, want 1 (not in cooldown)", hotCalls)
+	}
+	if coolCalls != 0 {
+		t.Errorf("app-cool Apps.ListRepos called %d times, want 0 (in cooldown)", coolCalls)
+	}
+}
+
+func TestHeartbeatOnce_RecordsPoolResponseOnSuccess(t *testing.T) {
+	now := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	pool := newQuotaPool(fixedNow(now))
+
+	cache := newHeartbeatTestCache(map[string]*fake.MockAppsClient{
+		"app-1": {
+			MockListRepos: func(ctx context.Context, opts *github.ListOptions) (*github.ListRepositories, *github.Response, error) {
+				return &github.ListRepositories{}, &github.Response{
+					Response: &http.Response{StatusCode: 200},
+					Rate:     github.Rate{Limit: 12500, Remaining: 12000, Reset: github.Timestamp{Time: now.Add(30 * time.Minute)}},
+				}, nil
+			},
+		},
+	})
+
+	heartbeatOnce(context.Background(), cache, pool, nil)
+
+	q := pool.snapshot("app-1")
+	if q.Remaining != 12000 {
+		t.Errorf("pool snapshot Remaining = %d, want 12000 (heartbeat response should be recorded)", q.Remaining)
+	}
+	if q.Limit != 12500 {
+		t.Errorf("pool snapshot Limit = %d, want 12500", q.Limit)
+	}
+}
+
+func TestHeartbeatOnce_RecordsPoolFailureSoFutureSkipsApply(t *testing.T) {
+	now := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	pool := newQuotaPool(fixedNow(now))
+
+	cache := newHeartbeatTestCache(map[string]*fake.MockAppsClient{
+		"app-broken": {
+			MockListRepos: func(ctx context.Context, opts *github.ListOptions) (*github.ListRepositories, *github.Response, error) {
+				return nil, nil, errors.New("token mint failed: 401")
+			},
+		},
+	})
+
+	heartbeatOnce(context.Background(), cache, pool, nil)
+
+	q := pool.snapshot("app-broken")
+	if q.ConsecutiveFailures == 0 {
+		t.Errorf("ConsecutiveFailures = 0, want >0 (failure should be recorded)")
+	}
+	if q.CooldownUntil.IsZero() || !q.CooldownUntil.After(now) {
+		t.Errorf("CooldownUntil = %v, want a future time", q.CooldownUntil)
+	}
+}

--- a/internal/clients/rate_limit_client.go
+++ b/internal/clients/rate_limit_client.go
@@ -98,9 +98,33 @@ func (rc *RateLimitClient) WithRateLimitTracking(org, appID, installationID, cac
 				installationID:     installationID,
 				cacheKey:           cacheKey,
 			},
+			Apps: &RateLimitAppsClient{
+				AppsClient:     rc.Apps,
+				metrics:        rc.metrics,
+				org:            org,
+				appID:          appID,
+				installationID: installationID,
+				cacheKey:       cacheKey,
+			},
 		},
 		metrics: rc.metrics,
 	}
+}
+
+// RateLimitAppsClient wraps the Apps client with rate limit tracking.
+type RateLimitAppsClient struct {
+	AppsClient
+	metrics        *telemetry.RateLimitMetrics
+	org            string
+	appID          string
+	installationID string
+	cacheKey       string
+}
+
+func (rac *RateLimitAppsClient) ListRepos(ctx context.Context, opts *github.ListOptions) (*github.ListRepositories, *github.Response, error) {
+	return recordRateLimit(ctx, rac.metrics, rac.org, rac.appID, rac.installationID, rac.cacheKey, "Apps.ListRepos", func() (*github.ListRepositories, *github.Response, error) {
+		return rac.AppsClient.ListRepos(ctx, opts)
+	})
 }
 
 // recordResponse fans the outcome of a GitHub call out to both Prometheus

--- a/internal/telemetry/rate_limit.go
+++ b/internal/telemetry/rate_limit.go
@@ -56,6 +56,10 @@ type RateLimitMetrics struct {
 	// random_tiebreak, only_candidate) so operators can see why each
 	// credential was chosen.
 	picksTotal *prometheus.CounterVec
+
+	// Heartbeat counters — total attempts and failures; pair to compute error rate.
+	heartbeatTotal       *prometheus.CounterVec
+	heartbeatErrorsTotal *prometheus.CounterVec
 }
 
 // labels carried by every rate-limit metric:
@@ -120,6 +124,20 @@ func newRateLimitMetrics() *RateLimitMetrics {
 			},
 			append(rateLimitLabels, "reason"),
 		),
+		heartbeatTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "github_app_heartbeat_total",
+				Help: "Total number of background heartbeat pings against each cached App installation, regardless of outcome.",
+			},
+			rateLimitLabels,
+		),
+		heartbeatErrorsTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "github_app_heartbeat_errors_total",
+				Help: "Total number of failed background heartbeat pings. Pair with github_app_heartbeat_total to compute error rate.",
+			},
+			rateLimitLabels,
+		),
 	}
 }
 
@@ -135,6 +153,8 @@ func NewRateLimitMetrics(_ ctrl.Manager) *RateLimitMetrics {
 	prometheus.MustRegister(m.appUnhealthyTotal)
 	prometheus.MustRegister(m.apiCallsTotal)
 	prometheus.MustRegister(m.picksTotal)
+	prometheus.MustRegister(m.heartbeatTotal)
+	prometheus.MustRegister(m.heartbeatErrorsTotal)
 
 	return m
 }
@@ -150,6 +170,16 @@ func NewForTest() *RateLimitMetrics {
 // given call. Counts every attempt, regardless of outcome.
 func (m *RateLimitMetrics) RecordAPICall(org, appID, installationID, method string) {
 	m.apiCallsTotal.WithLabelValues(org, appID, installationID, method).Inc()
+}
+
+// RecordAppHeartbeat increments github_app_heartbeat_total.
+func (m *RateLimitMetrics) RecordAppHeartbeat(org, appID, installationID string) {
+	m.heartbeatTotal.WithLabelValues(org, appID, installationID).Inc()
+}
+
+// RecordAppHeartbeatError increments github_app_heartbeat_errors_total.
+func (m *RateLimitMetrics) RecordAppHeartbeatError(org, appID, installationID string) {
+	m.heartbeatErrorsTotal.WithLabelValues(org, appID, installationID).Inc()
 }
 
 // RecordPickerPick increments the github_app_picker_picks_total counter


### PR DESCRIPTION
## Summary

- Background goroutine pings each GitHub App installation on a configurable interval (`--heartbeat-interval` / `HEARTBEAT_INTERVAL`, default `10m`) via `Apps.ListRepos`.
- Keeps GitHub-side authenticated activity registered so installations don't get demoted from the high rate-limit tier when the credential picker hasn't selected them for a stretch.
- Two new counters (`github_app_heartbeat_total` and `github_app_heartbeat_errors_total`) expose heartbeat health per installation.

## Problem

GitHub documents the primary rate-limit tier for an App installation as a function of the installation's org properties — 15,000/hr for Enterprise Cloud orgs, scaling from 5,000 up to 12,500 for standard orgs based on user and repo counts ([docs](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2026-03-10#primary-rate-limit-for-github-app-installations)). The docs don't describe activity-based demotion.

In practice we've observed installations that go without authenticated traffic for extended periods dropping to a hard ceiling of 500 requests/hour — well below even the documented 5,000/hr floor for standard orgs. The demotion is not documented by GitHub but is reproducible across distinct App IDs and recovers cleanly once the installation receives authenticated traffic. The mechanism (secondary rate limit, undocumented effective tier, abuse-prevention scaling) isn't disclosed; the symptom is consistent.

This is not a functional failure on its own — a demoted installation still serves requests, just with less headroom. The problem is fleet redundancy. The credential picker (introduced in #41) prefers the App with the most remaining headroom, so when one App is consistently picked, the others sit idle and get demoted. If the chosen App later hits 429 or runs into a transient issue, the picker tries to fall back — only to find the alternatives now have an effective ceiling of 500/hr, far too low to absorb the displaced load. Effective fleet capacity collapses to "whatever the currently-warm installation can do" instead of "sum of all installations".

The picker has no way to recover from this on its own; demoted installations need authenticated activity to come back.

## What changes

- **`internal/clients/heartbeat.go`** (new): background goroutine + per-installation ping loop. Skips installations currently in cooldown. Failures fall through the same `pool.recordResponse` plumbing controller traffic uses — 429s trigger pool cooldowns, transport failures trigger exponential backoff.
- **`cmd/provider/main.go`**: starts the goroutine alongside the existing `CleanupExpiredClients` ticker. New CLI flag `--heartbeat-interval` (or env var `HEARTBEAT_INTERVAL`), default `10m`.
- **`internal/clients/client.go`**: new `AppsClient` interface with one method, `ListRepos`. Same shape as existing service-specific interfaces.
- **`internal/clients/cached_client.go`**: `Client` struct now carries an `Apps` field; new `installationOrg` field on `cachedClientEntry` so heartbeat metrics carry the same `(organization, app_id, app_installation_id)` label tuple as controller-driven traffic. Two new cache helpers (`SnapshotCacheKeys`, `LookupEntry`).
- **`internal/clients/rate_limit_client.go`**: `RateLimitAppsClient` wrapper for consistency with the other service-specific wrappers.
- **`internal/clients/fake/client.go`**: matching `MockAppsClient`.
- **`internal/telemetry/rate_limit.go`**: two new counter vecs.

Heartbeat responses also feed `RecordRateLimitInfo`, so `github_rate_limit_remaining`/`_limit`/`_reset_time` stay fresh for installations the picker hasn't selected recently. Same metric shape as controller-driven updates — no synthetic labels.

## Why `Apps.ListRepos`

Callable with installation tokens, registers as authenticated activity, and cheap with `PerPage=1`.

## Test plan

- [x] Unit tests cover happy path, cooldown skip, pool-update on success, and exponential cooldown on transport failure.
- [x] End-to-end verification confirmed each known installation receives one ping per tick, both new counters increment as expected, `github_rate_limit_remaining` refreshes for installations the picker hasn't recently selected, and picker behavior is unchanged.
- [x] `make reviewable` clean.

## Notes

- Cost: one quota point per installation per tick. At the default 10-min interval that's ~6 calls/hr/installation of overhead.
- The heartbeat does not change the credential picker.
- No dependency bumps. No public API changes outside the internal `AppsClient` interface.
