### PR TITLE
Grant contents: write to the Tag workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   create-tag:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Grant `contents: write` to the `create-tag` job so the Tag workflow can create release tag refs again.

## Problem

The Tag workflow (`workflow_dispatch`) fails at the **Create Tag** step with `Resource not accessible by integration`. The org enforces a **read-only** default `GITHUB_TOKEN`, and the workflow declares no `permissions:` block — so `negz/create-tag@v1` cannot create the tag ref, which requires `contents: write`.

## What changes

- `.github/workflows/tag.yml`: add a job-level `permissions: { contents: write }` to `create-tag`.

An explicit `permissions:` block overrides the read-only default for this run only — the repo-wide default stays locked down (least privilege).

## Test plan

- [ ] Dispatch the Tag workflow with a `version` + `message`; confirm the Create Tag step succeeds and the tag appears.