### PR TITLE
Fix team controller reconcile loops on inherited and enforced members

### DIFF
--- a/examples/organizations/team.yaml
+++ b/examples/organizations/team.yaml
@@ -11,7 +11,7 @@ spec:
     members:
     - userRef:
         name: pgh-sample-user
-      role: maintainer # Note: If the user is an ORG admin, make sure to set it to "maintainer". GitHub enforces that ORG admins can only be maintainers in teams
+      role: maintainer # GitHub forces ORG admins to maintainer regardless of declared role
     privacy: closed
 ---
 apiVersion: organizations.github.crossplane.io/v1alpha1
@@ -28,5 +28,5 @@ spec:
     members:
     - userRef:
         name: pgh-sample-user
-      role: maintainer # Note: If the user is an ORG admin, make sure to set it to "maintainer". GitHub enforces that ORG admins can only be maintainers in teams
+      role: maintainer # GitHub forces ORG admins to maintainer regardless of declared role
     privacy: closed

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -443,6 +443,18 @@ func (c *teamsClient) RemoveTeamMembershipBySlug(ctx context.Context, org, slug,
 	return resp, err
 }
 
+func (c *teamsClient) ListPendingTeamInvitationsBySlug(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Invitation, *github.Response, error) {
+	return recordRateLimit(ctx, c.metrics, c.org, c.appID, c.installationID, c.cacheKey, "Teams.ListPendingTeamInvitationsBySlug", func() ([]*github.Invitation, *github.Response, error) {
+		return c.TeamsClient.ListPendingTeamInvitationsBySlug(ctx, org, slug, opts)
+	})
+}
+
+func (c *teamsClient) ListChildTeamsByParentSlug(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
+	return recordRateLimit(ctx, c.metrics, c.org, c.appID, c.installationID, c.cacheKey, "Teams.ListChildTeamsByParentSlug", func() ([]*github.Team, *github.Response, error) {
+		return c.TeamsClient.ListChildTeamsByParentSlug(ctx, org, slug, opts)
+	})
+}
+
 func (c *teamsClient) AddTeamRepoBySlug(ctx context.Context, org, slug, owner, repo string, opts *github.TeamAddTeamRepoOptions) (*github.Response, error) {
 	resp, err := c.TeamsClient.AddTeamRepoBySlug(ctx, org, slug, owner, repo, opts)
 	recordResponse(c.metrics, c.org, c.appID, c.installationID, c.cacheKey, "Teams.AddTeamRepoBySlug", resp, err)

--- a/internal/clients/fake/client.go
+++ b/internal/clients/fake/client.go
@@ -263,15 +263,17 @@ func (m *MockRepositoriesClient) ReplaceAllTopics(ctx context.Context, owner, re
 }
 
 type MockTeamsClient struct {
-	MockGetTeamBySlug              func(ctx context.Context, org, slug string) (*github.Team, *github.Response, error)
-	MockListTeamMembersBySlug      func(ctx context.Context, org, slug string, opts *github.TeamListTeamMembersOptions) ([]*github.User, *github.Response, error)
-	MockCreateTeam                 func(ctx context.Context, org string, team github.NewTeam) (*github.Team, *github.Response, error)
-	MockAddTeamMembershipBySlug    func(ctx context.Context, org, slug, user string, opts *github.TeamAddTeamMembershipOptions) (*github.Membership, *github.Response, error)
-	MockRemoveTeamMembershipBySlug func(ctx context.Context, org, slug, user string) (*github.Response, error)
-	MockEditTeamBySlug             func(ctx context.Context, org, slug string, team github.NewTeam, removeParent bool) (*github.Team, *github.Response, error)
-	MockDeleteTeamBySlug           func(ctx context.Context, org, slug string) (*github.Response, error)
-	MockAddTeamRepoBySlug          func(ctx context.Context, org, slug, owner, repo string, opts *github.TeamAddTeamRepoOptions) (*github.Response, error)
-	MockRemoveTeamRepoBySlug       func(ctx context.Context, org, slug, owner, repo string) (*github.Response, error)
+	MockGetTeamBySlug                    func(ctx context.Context, org, slug string) (*github.Team, *github.Response, error)
+	MockListTeamMembersBySlug            func(ctx context.Context, org, slug string, opts *github.TeamListTeamMembersOptions) ([]*github.User, *github.Response, error)
+	MockCreateTeam                       func(ctx context.Context, org string, team github.NewTeam) (*github.Team, *github.Response, error)
+	MockAddTeamMembershipBySlug          func(ctx context.Context, org, slug, user string, opts *github.TeamAddTeamMembershipOptions) (*github.Membership, *github.Response, error)
+	MockRemoveTeamMembershipBySlug       func(ctx context.Context, org, slug, user string) (*github.Response, error)
+	MockEditTeamBySlug                   func(ctx context.Context, org, slug string, team github.NewTeam, removeParent bool) (*github.Team, *github.Response, error)
+	MockDeleteTeamBySlug                 func(ctx context.Context, org, slug string) (*github.Response, error)
+	MockAddTeamRepoBySlug                func(ctx context.Context, org, slug, owner, repo string, opts *github.TeamAddTeamRepoOptions) (*github.Response, error)
+	MockRemoveTeamRepoBySlug             func(ctx context.Context, org, slug, owner, repo string) (*github.Response, error)
+	MockListPendingTeamInvitationsBySlug func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Invitation, *github.Response, error)
+	MockListChildTeamsByParentSlug       func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Team, *github.Response, error)
 }
 
 func (m *MockTeamsClient) RemoveTeamRepoBySlug(ctx context.Context, org, slug, owner, repo string) (*github.Response, error) {
@@ -308,6 +310,14 @@ func (m *MockTeamsClient) AddTeamMembershipBySlug(ctx context.Context, org, slug
 
 func (m *MockTeamsClient) AddTeamRepoBySlug(ctx context.Context, org, slug, owner, repo string, opts *github.TeamAddTeamRepoOptions) (*github.Response, error) {
 	return m.MockAddTeamRepoBySlug(ctx, org, slug, owner, repo, opts)
+}
+
+func (m *MockTeamsClient) ListPendingTeamInvitationsBySlug(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Invitation, *github.Response, error) {
+	return m.MockListPendingTeamInvitationsBySlug(ctx, org, slug, opts)
+}
+
+func (m *MockTeamsClient) ListChildTeamsByParentSlug(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
+	return m.MockListChildTeamsByParentSlug(ctx, org, slug, opts)
 }
 
 func Generate404Response() *github.ErrorResponse {

--- a/internal/clients/services.go
+++ b/internal/clients/services.go
@@ -71,6 +71,8 @@ type TeamsClient interface {
 	CreateTeam(ctx context.Context, org string, team github.NewTeam) (*github.Team, *github.Response, error)
 	AddTeamMembershipBySlug(ctx context.Context, org, slug, user string, opts *github.TeamAddTeamMembershipOptions) (*github.Membership, *github.Response, error)
 	RemoveTeamMembershipBySlug(ctx context.Context, org, slug, user string) (*github.Response, error)
+	ListPendingTeamInvitationsBySlug(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Invitation, *github.Response, error)
+	ListChildTeamsByParentSlug(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Team, *github.Response, error)
 	EditTeamBySlug(ctx context.Context, org, slug string, team github.NewTeam, removeParent bool) (*github.Team, *github.Response, error)
 	DeleteTeamBySlug(ctx context.Context, org, slug string) (*github.Response, error)
 	AddTeamRepoBySlug(ctx context.Context, org, slug, owner, repo string, opts *github.TeamAddTeamRepoOptions) (*github.Response, error)

--- a/internal/controller/team/team.go
+++ b/internal/controller/team/team.go
@@ -404,7 +404,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	crParentTeamSlug := slug.Make(pointer.Deref(cr.Spec.ForProvider.Parent, ""))
 	ghParentTeamSlug := ""
 	if t.Parent != nil {
-		ghParentTeamSlug = *t.Parent.Slug
+		ghParentTeamSlug = pointer.Deref(t.Parent.Slug, "")
 	}
 
 	structuralDrift := crParentTeamSlug != ghParentTeamSlug ||

--- a/internal/controller/team/team.go
+++ b/internal/controller/team/team.go
@@ -18,11 +18,14 @@ package team
 
 import (
 	"context"
-	"reflect"
+	"fmt"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	pointer "k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -45,7 +48,6 @@ import (
 	ghclient "github.com/crossplane/provider-github/internal/clients"
 	"github.com/crossplane/provider-github/internal/features"
 	"github.com/crossplane/provider-github/internal/telemetry"
-	"github.com/crossplane/provider-github/internal/util"
 )
 
 const (
@@ -131,6 +133,252 @@ type external struct {
 	github *ghclient.Client
 }
 
+const (
+	typeTeamMembershipPartial   xpv1.ConditionType   = "TeamMembershipPartial"
+	reasonPendingOrgMembership  xpv1.ConditionReason = "PendingOrgMembership"
+	reasonRoleEnforcedByOrg     xpv1.ConditionReason = "RoleEnforcedByOrg"
+	reasonPendingTeamInvitation xpv1.ConditionReason = "PendingTeamInvitation"
+	reasonAllMembersPresent     xpv1.ConditionReason = "AllMembersPresent"
+)
+
+// setTeamMembershipPartialCondition writes the CR-side condition reporting members the controller skipped.
+func setTeamMembershipPartialCondition(ctx context.Context, cr *v1alpha1.Team, pendingOrg, pendingTeam, roleEnforced []string) {
+	c := xpv1.Condition{
+		Type:               typeTeamMembershipPartial,
+		LastTransitionTime: metav1.Now(),
+	}
+	if len(pendingOrg) == 0 && len(pendingTeam) == 0 && len(roleEnforced) == 0 {
+		c.Status = corev1.ConditionFalse
+		c.Reason = reasonAllMembersPresent
+		cr.SetConditions(c)
+		return
+	}
+
+	c.Status = corev1.ConditionTrue
+	// Reason priority: most-actionable first.
+	switch {
+	case len(pendingOrg) > 0:
+		c.Reason = reasonPendingOrgMembership
+	case len(roleEnforced) > 0:
+		c.Reason = reasonRoleEnforcedByOrg
+	default:
+		c.Reason = reasonPendingTeamInvitation
+	}
+
+	var parts []string
+	if len(pendingOrg) > 0 {
+		sort.Strings(pendingOrg)
+		parts = append(parts, fmt.Sprintf("declared but not yet org members: %s", strings.Join(pendingOrg, ", ")))
+	}
+	if len(roleEnforced) > 0 {
+		sort.Strings(roleEnforced)
+		parts = append(parts, fmt.Sprintf("declared role overridden by GitHub org-admin enforcement: %s", strings.Join(roleEnforced, ", ")))
+	}
+	if len(pendingTeam) > 0 {
+		sort.Strings(pendingTeam)
+		parts = append(parts, fmt.Sprintf("residual pending team invitations: %s", strings.Join(pendingTeam, ", ")))
+	}
+	c.Message = strings.Join(parts, "; ")
+
+	ctrl.LoggerFrom(ctx).Info("team membership partial",
+		"team", meta.GetExternalName(cr),
+		"pendingOrg", pendingOrg,
+		"pendingTeam", pendingTeam,
+		"roleEnforced", roleEnforced)
+
+	cr.SetConditions(c)
+}
+
+// memberCategorization buckets CR and direct team members for Observe and Update.
+type memberCategorization struct {
+	// toRemove: users currently direct on the team but not in the CR.
+	toRemove map[string]string
+	// roleUpdate: users on the team in the CR but with a different role.
+	roleUpdate map[string]string
+	// inviteable: CR users who are active org members but not yet on the team.
+	inviteable map[string]string
+	// pendingOrg: CR users who are not active org members; skipped to avoid org-invite side effect.
+	pendingOrg []string
+	// pendingTeam: CR users with a residual unaccepted team invitation; treated as in flight.
+	pendingTeam []string
+	// roleEnforced: members whose role GitHub force-applies (org admins → maintainer).
+	roleEnforced []string
+}
+
+func (c *memberCategorization) hasMemberDrift() bool {
+	return len(c.toRemove) > 0 || len(c.roleUpdate) > 0 || len(c.inviteable) > 0
+}
+
+// categorizeMembers assigns the union of CR and direct team members to memberCategorization buckets.
+func categorizeMembers(ctx context.Context, gh *ghclient.Client, org, slug string, members []v1alpha1.TeamMemberUser) (*memberCategorization, error) {
+	crMToPermission := getUserPermissionMapFromCr(members)
+	rollup, err := getMembersWithPermissions(ctx, gh, org, slug)
+	if err != nil {
+		return nil, err
+	}
+	// Only members not yet on the team can have a pending invite; skip the fetch when there are none.
+	pendingSet := map[string]bool{}
+	for user := range crMToPermission {
+		if _, ok := rollup[user]; ok {
+			continue
+		}
+		pendingLogins, err := getPendingTeamInviteeLogins(ctx, gh, org, slug)
+		if err != nil {
+			return nil, err
+		}
+		for _, l := range pendingLogins {
+			pendingSet[l] = true
+		}
+		break
+	}
+	inheritedSet, err := collectChildMemberLogins(ctx, gh, org, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &memberCategorization{
+		toRemove:   make(map[string]string),
+		roleUpdate: make(map[string]string),
+		inviteable: make(map[string]string),
+	}
+
+	for user, ghRole := range rollup {
+		crRole, inCR := crMToPermission[user]
+		verdict, err := classifyRollupUser(ctx, gh, org, user, ghRole, crRole, inCR, inheritedSet[user])
+		if err != nil {
+			return nil, err
+		}
+		switch verdict {
+		case verdictRemove:
+			out.toRemove[user] = ghRole
+		case verdictUpdateRole:
+			out.roleUpdate[user] = crRole
+		case verdictRoleEnforced:
+			out.roleEnforced = append(out.roleEnforced, user)
+		case verdictNone:
+			// In sync, or an inherited member the controller must not touch.
+		}
+	}
+
+	for user, crRole := range crMToPermission {
+		if _, ok := rollup[user]; ok {
+			continue
+		}
+		if pendingSet[user] {
+			out.pendingTeam = append(out.pendingTeam, user)
+			continue
+		}
+		active, err := isActiveOrgMember(ctx, gh, org, user)
+		if err != nil {
+			return nil, err
+		}
+		if !active {
+			out.pendingOrg = append(out.pendingOrg, user)
+			continue
+		}
+		out.inviteable[user] = crRole
+	}
+
+	return out, nil
+}
+
+// rollupVerdict is the disposition of a single user from the team rollup,
+// decided by classifyRollupUser.
+type rollupVerdict int
+
+const (
+	// verdictNone: in sync, or an inherited member the controller must not touch.
+	verdictNone rollupVerdict = iota
+	// verdictRemove: a direct membership absent from the CR.
+	verdictRemove
+	// verdictUpdateRole: declared in the CR with a different, settable role.
+	verdictUpdateRole
+	// verdictRoleEnforced: declared role is overridden by GitHub org-admin enforcement.
+	verdictRoleEnforced
+)
+
+// classifyRollupUser decides what to do with one user from the team rollup, given
+// whether the CR declares them, their declared vs effective role, and whether they
+// are inherited from a child team. The org-admin probe runs only in the two cases
+// where a maintainer role could be GitHub-enforced rather than directly granted.
+func classifyRollupUser(ctx context.Context, gh *ghclient.Client, org, user, ghRole, crRole string, inCR, inherited bool) (rollupVerdict, error) {
+	if !inCR {
+		if !inherited {
+			// Direct membership, not inherited → removable.
+			return verdictRemove, nil
+		}
+		// Inherited from a child team. A member-role entry is purely inherited, so a
+		// parent-level DELETE no-ops — leave it. A maintainer-role entry is either a
+		// rogue direct grant layered on the inherited membership (DELETE demotes it to
+		// inherited member → converges) or an org admin (maintainer of every team;
+		// DELETE can't strip it → would loop). Remove only the former.
+		if ghRole != "maintainer" {
+			return verdictNone, nil
+		}
+		admin, err := isOrgAdmin(ctx, gh, org, user)
+		if err != nil {
+			return verdictNone, err
+		}
+		if admin {
+			return verdictNone, nil
+		}
+		return verdictRemove, nil
+	}
+	// Declared in the CR.
+	if crRole == ghRole {
+		return verdictNone, nil
+	}
+	// Role mismatch. Only (GH=maintainer, CR=else) can be GitHub-enforced: GitHub
+	// force-applies maintainer to org admins regardless of the declared role.
+	if ghRole == "maintainer" {
+		enforced, err := isOrgAdmin(ctx, gh, org, user)
+		if err != nil {
+			return verdictNone, err
+		}
+		if enforced {
+			return verdictRoleEnforced, nil
+		}
+	}
+	return verdictUpdateRole, nil
+}
+
+const (
+	orgRoleAdmin   = "admin"
+	orgStateActive = "active"
+)
+
+// isOrgAdmin returns true exactly when the user is an org-level admin. False for 404 / unknown.
+func isOrgAdmin(ctx context.Context, gh *ghclient.Client, org, user string) (bool, error) {
+	membership, _, err := gh.Organizations.GetOrgMembership(ctx, user, org)
+	if ghclient.Is404(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if membership == nil || membership.Role == nil {
+		return false, nil
+	}
+	return *membership.Role == orgRoleAdmin, nil
+}
+
+// isActiveOrgMember returns true exactly when the user has an active org membership.
+// Returns false for 404 (not a member) and for non-active states (pending
+// invite). Other errors propagate.
+func isActiveOrgMember(ctx context.Context, gh *ghclient.Client, org, user string) (bool, error) {
+	membership, _, err := gh.Organizations.GetOrgMembership(ctx, user, org)
+	if ghclient.Is404(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if membership == nil || membership.State == nil {
+		return false, nil
+	}
+	return *membership.State == orgStateActive, nil
+}
+
 func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
 	cr, ok := mg.(*v1alpha1.Team)
 	if !ok {
@@ -148,8 +396,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, err
 	}
 
-	crMToPermission := getUserPermissionMapFromCr(cr.Spec.ForProvider.Members)
-	ghMToPermission, err := getMembersWithPermissions(ctx, c.github, cr.Spec.ForProvider.Org, teamSlug)
+	categorized, err := categorizeMembers(ctx, c.github, cr.Spec.ForProvider.Org, teamSlug, cr.Spec.ForProvider.Members)
 	if err != nil {
 		return managed.ExternalObservation{}, err
 	}
@@ -160,11 +407,13 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		ghParentTeamSlug = *t.Parent.Slug
 	}
 
-	if crParentTeamSlug != ghParentTeamSlug ||
-		pointer.Deref(cr.Spec.ForProvider.Privacy, "secret") != *t.Privacy ||
-		cr.Spec.ForProvider.Description != *t.Description ||
-		!reflect.DeepEqual(util.SortByKey(ghMToPermission), util.SortByKey(crMToPermission)) {
+	structuralDrift := crParentTeamSlug != ghParentTeamSlug ||
+		pointer.Deref(cr.Spec.ForProvider.Privacy, "secret") != pointer.Deref(t.Privacy, "secret") ||
+		cr.Spec.ForProvider.Description != pointer.Deref(t.Description, "")
 
+	setTeamMembershipPartialCondition(ctx, cr, categorized.pendingOrg, categorized.pendingTeam, categorized.roleEnforced)
+
+	if structuralDrift || categorized.hasMemberDrift() {
 		return managed.ExternalObservation{
 			ResourceExists:   true,
 			ResourceUpToDate: false,
@@ -190,8 +439,32 @@ func getUserPermissionMapFromCr(users []v1alpha1.TeamMemberUser) map[string]stri
 	return crMToPermission
 }
 
+// getPendingTeamInviteeLogins returns lowercased logins with a pending team invitation. Email-only invitations are skipped.
+func getPendingTeamInviteeLogins(ctx context.Context, gh *ghclient.Client, org, slug string) ([]string, error) {
+	opts := &github.ListOptions{PerPage: 100}
+	var logins []string
+	for {
+		invitations, resp, err := gh.Teams.ListPendingTeamInvitationsBySlug(ctx, org, slug, opts)
+		if err != nil {
+			return nil, err
+		}
+		for _, inv := range invitations {
+			if inv == nil || inv.Login == nil {
+				continue
+			}
+			logins = append(logins, strings.ToLower(*inv.Login))
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return logins, nil
+}
+
 func getMembersWithPermissions(ctx context.Context, gh *ghclient.Client, org, slug string) (map[string]string, error) {
 	mToPermission := make(map[string]string)
+	// maintainer last: a user can be both an inherited member and a direct maintainer; querying maintainer last makes it win.
 	roles := []string{"member", "maintainer"}
 
 	for _, role := range roles {
@@ -207,11 +480,14 @@ func getMembersWithPermissions(ctx context.Context, gh *ghclient.Client, org, sl
 			}
 
 			for _, m := range members {
+				if m == nil || m.Login == nil {
+					continue
+				}
 				username := strings.ToLower(*m.Login)
 				mToPermission[username] = role
 			}
 
-			if resp.NextPage == 0 {
+			if resp == nil || resp.NextPage == 0 {
 				break
 			}
 			opt.Page = resp.NextPage
@@ -219,6 +495,48 @@ func getMembersWithPermissions(ctx context.Context, gh *ghclient.Client, org, sl
 	}
 
 	return mToPermission, nil
+}
+
+// collectChildMemberLogins returns the union of logins across all direct child
+// rollups. Used as an inheritance hint when categorizing parent rollup entries.
+func collectChildMemberLogins(ctx context.Context, gh *ghclient.Client, org, slug string) (map[string]bool, error) {
+	children, err := listChildTeamSlugs(ctx, gh, org, slug)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]bool)
+	for _, childSlug := range children {
+		childMembers, err := getMembersWithPermissions(ctx, gh, org, childSlug)
+		if err != nil {
+			return nil, err
+		}
+		for login := range childMembers {
+			out[login] = true
+		}
+	}
+	return out, nil
+}
+
+func listChildTeamSlugs(ctx context.Context, gh *ghclient.Client, org, parentSlug string) ([]string, error) {
+	opts := &github.ListOptions{PerPage: 100}
+	var slugs []string
+	for {
+		teams, resp, err := gh.Teams.ListChildTeamsByParentSlug(ctx, org, parentSlug, opts)
+		if err != nil {
+			return nil, err
+		}
+		for _, t := range teams {
+			if t == nil || t.Slug == nil {
+				continue
+			}
+			slugs = append(slugs, *t.Slug)
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return slugs, nil
 }
 
 func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
@@ -241,44 +559,36 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalCreation{}, err
 	}
 
-	if cr.Spec.ForProvider.Members != nil {
-		for _, user := range cr.Spec.ForProvider.Members {
-			opt := &github.TeamAddTeamMembershipOptions{
-				Role: user.Role,
-			}
-			_, _, err = c.github.Teams.AddTeamMembershipBySlug(ctx, cr.Spec.ForProvider.Org, teamSlug, user.User, opt)
-			if err != nil {
-				return managed.ExternalCreation{}, err
-			}
-		}
+	if err := updateTeamUsers(ctx, cr, c.github, teamSlug); err != nil {
+		return managed.ExternalCreation{}, err
 	}
 
 	return managed.ExternalCreation{}, nil
 }
 
 func updateTeamUsers(ctx context.Context, cr *v1alpha1.Team, gh *ghclient.Client, teamSlug string) error {
-	crMToPermission := getUserPermissionMapFromCr(cr.Spec.ForProvider.Members)
-	ghMToPermission, err := getMembersWithPermissions(ctx, gh, cr.Spec.ForProvider.Org, teamSlug)
+	categorized, err := categorizeMembers(ctx, gh, cr.Spec.ForProvider.Org, teamSlug, cr.Spec.ForProvider.Members)
 	if err != nil {
 		return err
 	}
 
-	toDelete, toInvite, toUpdate := util.DiffPermissions(ghMToPermission, crMToPermission)
-
-	for userName := range toDelete {
+	for userName := range categorized.toRemove {
 		_, err := gh.Teams.RemoveTeamMembershipBySlug(ctx, cr.Spec.ForProvider.Org, teamSlug, userName)
 		if err != nil {
 			return err
 		}
 	}
 
-	for userName, role := range util.MergeMaps(toInvite, toUpdate) {
-		opt := &github.TeamAddTeamMembershipOptions{
-			Role: role,
+	// inviteable only: PUT for non-org-members would send an org-invite side effect.
+	for userName, role := range categorized.inviteable {
+		opt := &github.TeamAddTeamMembershipOptions{Role: role}
+		if _, _, err := gh.Teams.AddTeamMembershipBySlug(ctx, cr.Spec.ForProvider.Org, teamSlug, userName, opt); err != nil {
+			return err
 		}
-
-		_, _, err = gh.Teams.AddTeamMembershipBySlug(ctx, cr.Spec.ForProvider.Org, teamSlug, userName, opt)
-		if err != nil {
+	}
+	for userName, role := range categorized.roleUpdate {
+		opt := &github.TeamAddTeamMembershipOptions{Role: role}
+		if _, _, err := gh.Teams.AddTeamMembershipBySlug(ctx, cr.Spec.ForProvider.Org, teamSlug, userName, opt); err != nil {
 			return err
 		}
 	}

--- a/internal/controller/team/team_test.go
+++ b/internal/controller/team/team_test.go
@@ -27,6 +27,7 @@ import (
 	ghclient "github.com/crossplane/provider-github/internal/clients"
 	"github.com/crossplane/provider-github/internal/clients/fake"
 
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -49,9 +50,26 @@ var (
 	member1Role = "maintainer"
 	member2     = "test-user-2"
 	member2Role = "member"
+	member3     = "test-user-3"
+	member3Role = "member"
 )
 
 type teamModifier func(*v1alpha1.Team)
+
+func withExtraMember(user, role string) teamModifier {
+	return func(cr *v1alpha1.Team) {
+		cr.Spec.ForProvider.Members = append(cr.Spec.ForProvider.Members, v1alpha1.TeamMemberUser{
+			User: user,
+			Role: role,
+		})
+	}
+}
+
+func withSoleMember(user, role string) teamModifier {
+	return func(cr *v1alpha1.Team) {
+		cr.Spec.ForProvider.Members = []v1alpha1.TeamMemberUser{{User: user, Role: role}}
+	}
+}
 
 // func withProperty() teamModifier {
 // 	return func(r *v1alpha1.Team) {
@@ -113,6 +131,8 @@ func TestObserve(t *testing.T) {
 	type want struct {
 		o   managed.ExternalObservation
 		err error
+		// partialReason: if non-empty, asserts TeamMembershipPartial reason after Observe.
+		partialReason xpv1.ConditionReason
 	}
 
 	cases := map[string]struct {
@@ -135,6 +155,12 @@ func TestObserve(t *testing.T) {
 							MockListTeamMembersBySlug: func(ctx context.Context, org, slug string, opts *github.TeamListTeamMembersOptions) ([]*github.User, *github.Response, error) {
 								return githubTeam(opts.Role), fake.GenerateEmptyResponse(), nil
 							},
+							MockListPendingTeamInvitationsBySlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Invitation, *github.Response, error) {
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListChildTeamsByParentSlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
 						},
 					},
 				},
@@ -150,6 +176,539 @@ func TestObserve(t *testing.T) {
 				err: nil,
 			},
 		},
+		// A pending team invitation is in-flight work, not drift.
+		"UpToDate_PendingInviteFulfillsDeclaredMember": {
+			fields: fields{
+				github: &ghclient.Client{
+					Services: &ghclient.Services{
+						Teams: &fake.MockTeamsClient{
+							MockGetTeamBySlug: func(ctx context.Context, org, slug string) (*github.Team, *github.Response, error) {
+								return &github.Team{
+									Privacy:     &teamPrivacy,
+									Description: &teamDescription,
+								}, nil, nil
+							},
+							MockListTeamMembersBySlug: func(ctx context.Context, org, slug string, opts *github.TeamListTeamMembersOptions) ([]*github.User, *github.Response, error) {
+								return githubTeam(opts.Role), fake.GenerateEmptyResponse(), nil
+							},
+							MockListPendingTeamInvitationsBySlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Invitation, *github.Response, error) {
+								return []*github.Invitation{
+									{Login: &member3},
+								}, fake.GenerateEmptyResponse(), nil
+							},
+							MockListChildTeamsByParentSlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				mg: team(withExtraMember(member3, member3Role)),
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: true,
+				},
+				err:           nil,
+				partialReason: reasonPendingTeamInvitation,
+			},
+		},
+		// Active org member declared on team but absent must drift to inviteable.
+		"Drift_DeclaredMemberIsActiveOrgMember": {
+			fields: fields{
+				github: &ghclient.Client{
+					Services: &ghclient.Services{
+						Teams: &fake.MockTeamsClient{
+							MockGetTeamBySlug: func(ctx context.Context, org, slug string) (*github.Team, *github.Response, error) {
+								return &github.Team{
+									Privacy:     &teamPrivacy,
+									Description: &teamDescription,
+								}, nil, nil
+							},
+							MockListTeamMembersBySlug: func(ctx context.Context, org, slug string, opts *github.TeamListTeamMembersOptions) ([]*github.User, *github.Response, error) {
+								return githubTeam(opts.Role), fake.GenerateEmptyResponse(), nil
+							},
+							MockListPendingTeamInvitationsBySlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Invitation, *github.Response, error) {
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListChildTeamsByParentSlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+						},
+						Organizations: &fake.MockOrganizationsClient{
+							MockGetOrgMembership: func(ctx context.Context, user, org string) (*github.Membership, *github.Response, error) {
+								active := "active"
+								return &github.Membership{State: &active}, fake.GenerateEmptyResponse(), nil
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				mg: team(withExtraMember(member3, member3Role)),
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: false,
+				},
+				err: nil,
+			},
+		},
+		// A non-admin's direct maintainer grant on the parent, layered on their
+		// inherited child membership, is a rogue override: the DELETE strips the
+		// direct grant and demotes them to inherited member, so toRemove must fire.
+		// (Contrast UpToDate_InheritedOrgAdminMaintainerSkipped, where the maintainer
+		// status is org-admin-derived and unremovable.)
+		"Drift_DirectOverrideOnChildInheritedUser": {
+			fields: fields{
+				github: &ghclient.Client{
+					Services: &ghclient.Services{
+						Teams: &fake.MockTeamsClient{
+							MockGetTeamBySlug: func(ctx context.Context, org, slug string) (*github.Team, *github.Response, error) {
+								return &github.Team{
+									Privacy:     &teamPrivacy,
+									Description: &teamDescription,
+								}, nil, nil
+							},
+							MockListTeamMembersBySlug: func(ctx context.Context, org, slug string, opts *github.TeamListTeamMembersOptions) ([]*github.User, *github.Response, error) {
+								// Parent (slug==""): member3 appears as MAINTAINER (direct
+								// override), not as member (which is the child's role).
+								if slug == "" {
+									if opts.Role == "maintainer" {
+										return []*github.User{{Login: &member1}, {Login: &member3}}, fake.GenerateEmptyResponse(), nil
+									}
+									return []*github.User{{Login: &member2}}, fake.GenerateEmptyResponse(), nil
+								}
+								// Child team: member3 as member only.
+								if opts.Role == "member" {
+									return []*github.User{{Login: &member3}}, fake.GenerateEmptyResponse(), nil
+								}
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListPendingTeamInvitationsBySlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Invitation, *github.Response, error) {
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListChildTeamsByParentSlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
+								if slug == "" {
+									childSlug := "child-team"
+									return []*github.Team{{Slug: &childSlug}}, fake.GenerateEmptyResponse(), nil
+								}
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+						},
+						Organizations: &fake.MockOrganizationsClient{
+							MockGetOrgMembership: func(ctx context.Context, user, org string) (*github.Membership, *github.Response, error) {
+								role := "member"
+								return &github.Membership{Role: &role}, fake.GenerateEmptyResponse(), nil
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				mg: team(),
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: false,
+				},
+				err: nil,
+			},
+		},
+		// An org admin appears in the parent rollup as maintainer (org admins are
+		// maintainers of every team they belong to) while being inherited from a
+		// child and absent from the CR. A parent-level DELETE cannot strip org-admin
+		// maintainer status, so flagging toRemove no-ops and reconcile-loops forever.
+		"UpToDate_InheritedOrgAdminMaintainerSkipped": {
+			fields: fields{
+				github: &ghclient.Client{
+					Services: &ghclient.Services{
+						Teams: &fake.MockTeamsClient{
+							MockGetTeamBySlug: func(ctx context.Context, org, slug string) (*github.Team, *github.Response, error) {
+								return &github.Team{
+									Privacy:     &teamPrivacy,
+									Description: &teamDescription,
+								}, nil, nil
+							},
+							MockListTeamMembersBySlug: func(ctx context.Context, org, slug string, opts *github.TeamListTeamMembersOptions) ([]*github.User, *github.Response, error) {
+								// Parent (slug==""): member3 appears as maintainer (org-admin
+								// derived), not in the CR; member1/member2 match the CR.
+								if slug == "" {
+									if opts.Role == "maintainer" {
+										return []*github.User{{Login: &member1}, {Login: &member3}}, fake.GenerateEmptyResponse(), nil
+									}
+									return []*github.User{{Login: &member2}}, fake.GenerateEmptyResponse(), nil
+								}
+								// Child team: member3 is a member (the inheritance source).
+								if opts.Role == "member" {
+									return []*github.User{{Login: &member3}}, fake.GenerateEmptyResponse(), nil
+								}
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListPendingTeamInvitationsBySlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Invitation, *github.Response, error) {
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListChildTeamsByParentSlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
+								if slug == "" {
+									childSlug := "child-team"
+									return []*github.Team{{Slug: &childSlug}}, fake.GenerateEmptyResponse(), nil
+								}
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+						},
+						Organizations: &fake.MockOrganizationsClient{
+							MockGetOrgMembership: func(ctx context.Context, user, org string) (*github.Membership, *github.Response, error) {
+								role := "admin"
+								state := "active"
+								return &github.Membership{Role: &role, State: &state}, fake.GenerateEmptyResponse(), nil
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				mg: team(),
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: true,
+				},
+				err: nil,
+			},
+		},
+		// Inherited-only user at role=member must not be flagged toRemove —
+		// DELETE on a purely-inherited membership silently no-ops and would loop.
+		"UpToDate_InheritedOnlyMemberSkipsToRemove": {
+			fields: fields{
+				github: &ghclient.Client{
+					Services: &ghclient.Services{
+						Teams: &fake.MockTeamsClient{
+							MockGetTeamBySlug: func(ctx context.Context, org, slug string) (*github.Team, *github.Response, error) {
+								return &github.Team{
+									Privacy:     &teamPrivacy,
+									Description: &teamDescription,
+								}, nil, nil
+							},
+							MockListTeamMembersBySlug: func(ctx context.Context, org, slug string, opts *github.TeamListTeamMembersOptions) ([]*github.User, *github.Response, error) {
+								// Parent (slug==""): member1 direct maintainer, member3 as member (inherited only).
+								if slug == "" {
+									if opts.Role == "maintainer" {
+										return []*github.User{{Login: &member1}}, fake.GenerateEmptyResponse(), nil
+									}
+									return []*github.User{{Login: &member3}}, fake.GenerateEmptyResponse(), nil
+								}
+								// Child: member3 as maintainer (mismatched role with parent's inheritance default).
+								if opts.Role == "maintainer" {
+									return []*github.User{{Login: &member3}}, fake.GenerateEmptyResponse(), nil
+								}
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListPendingTeamInvitationsBySlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Invitation, *github.Response, error) {
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListChildTeamsByParentSlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
+								if slug == "" {
+									childSlug := "child-team"
+									return []*github.Team{{Slug: &childSlug}}, fake.GenerateEmptyResponse(), nil
+								}
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				mg: team(withSoleMember(member1, member1Role)),
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: true,
+				},
+				err: nil,
+			},
+		},
+		// CR-declared user inherited at matching role must not loop on AddTeamMembership —
+		// the parent rollup already contains them, no inviteable PUT needed.
+		"UpToDate_CRDeclaredAlsoInheritedAtMatchingRole": {
+			fields: fields{
+				github: &ghclient.Client{
+					Services: &ghclient.Services{
+						Teams: &fake.MockTeamsClient{
+							MockGetTeamBySlug: func(ctx context.Context, org, slug string) (*github.Team, *github.Response, error) {
+								return &github.Team{
+									Privacy:     &teamPrivacy,
+									Description: &teamDescription,
+								}, nil, nil
+							},
+							MockListTeamMembersBySlug: func(ctx context.Context, org, slug string, opts *github.TeamListTeamMembersOptions) ([]*github.User, *github.Response, error) {
+								// Parent and child both report member3 as member.
+								if opts.Role == "member" {
+									return []*github.User{{Login: &member3}}, fake.GenerateEmptyResponse(), nil
+								}
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListPendingTeamInvitationsBySlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Invitation, *github.Response, error) {
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListChildTeamsByParentSlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
+								if slug == "" {
+									childSlug := "child-team"
+									return []*github.Team{{Slug: &childSlug}}, fake.GenerateEmptyResponse(), nil
+								}
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				mg: team(withSoleMember(member3, member3Role)),
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: true,
+				},
+				err: nil,
+			},
+		},
+		// Inherited child-team members must subtract out of the parent's rollup, else parent reconcile-fights forever.
+		"UpToDate_ChildTeamRollupSubtracted": {
+			fields: fields{
+				github: &ghclient.Client{
+					Services: &ghclient.Services{
+						Teams: &fake.MockTeamsClient{
+							MockGetTeamBySlug: func(ctx context.Context, org, slug string) (*github.Team, *github.Response, error) {
+								return &github.Team{
+									Privacy:     &teamPrivacy,
+									Description: &teamDescription,
+								}, nil, nil
+							},
+							MockListTeamMembersBySlug: func(ctx context.Context, org, slug string, opts *github.TeamListTeamMembersOptions) ([]*github.User, *github.Response, error) {
+								// Parent (slug=="") rollup includes the CR-declared members
+								// plus member3 inherited from the child team.
+								if slug == "" {
+									if opts.Role == "maintainer" {
+										return []*github.User{{Login: &member1}}, fake.GenerateEmptyResponse(), nil
+									}
+									return []*github.User{{Login: &member2}, {Login: &member3}}, fake.GenerateEmptyResponse(), nil
+								}
+								// Child team contributes only member3 (the inherited one).
+								if opts.Role == "member" {
+									return []*github.User{{Login: &member3}}, fake.GenerateEmptyResponse(), nil
+								}
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListPendingTeamInvitationsBySlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Invitation, *github.Response, error) {
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListChildTeamsByParentSlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
+								childSlug := "child-team"
+								return []*github.Team{{Slug: &childSlug}}, fake.GenerateEmptyResponse(), nil
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				mg: team(),
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: true,
+				},
+				err: nil,
+			},
+		},
+		// Declared non-org-member must NOT PUT (org-invite side effect); surface via partial condition.
+		"UpToDate_DeclaredButPendingOrgMembership": {
+			fields: fields{
+				github: &ghclient.Client{
+					Services: &ghclient.Services{
+						Teams: &fake.MockTeamsClient{
+							MockGetTeamBySlug: func(ctx context.Context, org, slug string) (*github.Team, *github.Response, error) {
+								return &github.Team{
+									Privacy:     &teamPrivacy,
+									Description: &teamDescription,
+								}, nil, nil
+							},
+							MockListTeamMembersBySlug: func(ctx context.Context, org, slug string, opts *github.TeamListTeamMembersOptions) ([]*github.User, *github.Response, error) {
+								return githubTeam(opts.Role), fake.GenerateEmptyResponse(), nil
+							},
+							MockListPendingTeamInvitationsBySlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Invitation, *github.Response, error) {
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListChildTeamsByParentSlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+						},
+						Organizations: &fake.MockOrganizationsClient{
+							MockGetOrgMembership: func(ctx context.Context, user, org string) (*github.Membership, *github.Response, error) {
+								return nil, nil, fake.Generate404Response()
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				mg: team(withExtraMember(member3, member3Role)),
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: true,
+				},
+				err:           nil,
+				partialReason: reasonPendingOrgMembership,
+			},
+		},
+		// (GH=member, CR=maintainer) is a legitimate operator promotion — GitHub
+		// will accept the PUT. The isOrgAdmin probe must not fire here; otherwise
+		// every promotion costs an extra Organizations.GetOrgMembership call.
+		"Drift_PromotionToMaintainerSkipsOrgAdminProbe": {
+			fields: fields{
+				github: &ghclient.Client{
+					Services: &ghclient.Services{
+						Teams: &fake.MockTeamsClient{
+							MockGetTeamBySlug: func(ctx context.Context, org, slug string) (*github.Team, *github.Response, error) {
+								return &github.Team{
+									Privacy:     &teamPrivacy,
+									Description: &teamDescription,
+								}, nil, nil
+							},
+							MockListTeamMembersBySlug: func(ctx context.Context, org, slug string, opts *github.TeamListTeamMembersOptions) ([]*github.User, *github.Response, error) {
+								if opts.Role == "member" {
+									return []*github.User{{Login: &member1}}, fake.GenerateEmptyResponse(), nil
+								}
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListPendingTeamInvitationsBySlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Invitation, *github.Response, error) {
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListChildTeamsByParentSlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+						},
+						Organizations: &fake.MockOrganizationsClient{
+							MockGetOrgMembership: func(ctx context.Context, user, org string) (*github.Membership, *github.Response, error) {
+								panic("GetOrgMembership must not be called for (ghRole=member, crRole=maintainer)")
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				mg: team(withSoleMember(member1, "maintainer")),
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: false,
+				},
+				err: nil,
+			},
+		},
+		// Org admin with CR role != GH-enforced role must route to roleEnforced,
+		// else Observe loops on no-op PUTs forever.
+		"UpToDate_OrgAdminRoleEnforced": {
+			fields: fields{
+				github: &ghclient.Client{
+					Services: &ghclient.Services{
+						Teams: &fake.MockTeamsClient{
+							MockGetTeamBySlug: func(ctx context.Context, org, slug string) (*github.Team, *github.Response, error) {
+								return &github.Team{
+									Privacy:     &teamPrivacy,
+									Description: &teamDescription,
+								}, nil, nil
+							},
+							MockListTeamMembersBySlug: func(ctx context.Context, org, slug string, opts *github.TeamListTeamMembersOptions) ([]*github.User, *github.Response, error) {
+								if opts.Role == "maintainer" {
+									return []*github.User{{Login: &member1}}, fake.GenerateEmptyResponse(), nil
+								}
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListPendingTeamInvitationsBySlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Invitation, *github.Response, error) {
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListChildTeamsByParentSlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+						},
+						Organizations: &fake.MockOrganizationsClient{
+							MockGetOrgMembership: func(ctx context.Context, user, org string) (*github.Membership, *github.Response, error) {
+								role := "admin"
+								state := "active"
+								return &github.Membership{Role: &role, State: &state}, fake.GenerateEmptyResponse(), nil
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				mg: team(withSoleMember(member1, "member")),
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: true,
+				},
+				err:           nil,
+				partialReason: reasonRoleEnforcedByOrg,
+			},
+		},
+		"Drift_DirectMemberNotInCRWithChild": {
+			fields: fields{
+				github: &ghclient.Client{
+					Services: &ghclient.Services{
+						Teams: &fake.MockTeamsClient{
+							MockGetTeamBySlug: func(ctx context.Context, org, slug string) (*github.Team, *github.Response, error) {
+								return &github.Team{
+									Privacy:     &teamPrivacy,
+									Description: &teamDescription,
+								}, nil, nil
+							},
+							MockListTeamMembersBySlug: func(ctx context.Context, org, slug string, opts *github.TeamListTeamMembersOptions) ([]*github.User, *github.Response, error) {
+								// Parent rollup: the two CR-declared members plus a third
+								// who is a *direct* parent member (NOT inherited from the
+								// child, whose rollup below is empty).
+								if slug == "" {
+									if opts.Role == "maintainer" {
+										return []*github.User{{Login: &member1}}, fake.GenerateEmptyResponse(), nil
+									}
+									return []*github.User{{Login: &member2}, {Login: &member3}}, fake.GenerateEmptyResponse(), nil
+								}
+								// Child team has no members.
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListPendingTeamInvitationsBySlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Invitation, *github.Response, error) {
+								return nil, fake.GenerateEmptyResponse(), nil
+							},
+							MockListChildTeamsByParentSlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
+								childSlug := "child-team"
+								return []*github.Team{{Slug: &childSlug}}, fake.GenerateEmptyResponse(), nil
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				mg: team(),
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: false,
+				},
+				err: nil,
+			},
+		},
 	}
 
 	for name, tc := range cases {
@@ -161,6 +720,101 @@ func TestObserve(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.o, got); diff != "" {
 				t.Errorf("\n%s\ne.Observe(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+			if tc.want.partialReason != "" {
+				teamCR := tc.args.mg.(*v1alpha1.Team)
+				var found *xpv1.Condition
+				for i := range teamCR.Status.Conditions {
+					if teamCR.Status.Conditions[i].Type == "TeamMembershipPartial" {
+						found = &teamCR.Status.Conditions[i]
+						break
+					}
+				}
+				if found == nil {
+					t.Errorf("%s: TeamMembershipPartial condition not set", tc.reason)
+				} else if found.Reason != tc.want.partialReason {
+					t.Errorf("%s: TeamMembershipPartial reason = %q, want %q (message=%q)", tc.reason, found.Reason, tc.want.partialReason, found.Message)
+				}
+			}
+		})
+	}
+}
+
+// TestCreate verifies the org-membership gate inside Create. PUT to team
+// membership for a non-org-member would send an org-level invitation as a
+// side effect (the Membership CR's job). Create must skip such users; the
+// next Observe surfaces them via TeamMembershipPartial.
+func TestCreate(t *testing.T) {
+	type want struct {
+		err      error
+		addCalls int
+	}
+
+	cases := map[string]struct {
+		reason  string
+		members []v1alpha1.TeamMemberUser
+		active  bool
+		want    want
+	}{
+		"ActiveOrgMember_GetsPUT": {
+			reason:  "An active org member declared on the team must be PUT into team membership.",
+			members: []v1alpha1.TeamMemberUser{{User: member1, Role: member1Role}},
+			active:  true,
+			want:    want{addCalls: 1},
+		},
+		"NonOrgMember_SkipsPUT": {
+			reason:  "A non-org-member declared on the team must NOT be PUT — PUT would send an org invite as a side effect.",
+			members: []v1alpha1.TeamMemberUser{{User: member3, Role: member3Role}},
+			active:  false,
+			want:    want{addCalls: 0},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			addCalls := 0
+			gh := &ghclient.Client{
+				Services: &ghclient.Services{
+					Teams: &fake.MockTeamsClient{
+						MockCreateTeam: func(ctx context.Context, org string, t github.NewTeam) (*github.Team, *github.Response, error) {
+							return &github.Team{}, fake.GenerateEmptyResponse(), nil
+						},
+						MockAddTeamMembershipBySlug: func(ctx context.Context, org, slug, user string, opts *github.TeamAddTeamMembershipOptions) (*github.Membership, *github.Response, error) {
+							addCalls++
+							return &github.Membership{}, fake.GenerateEmptyResponse(), nil
+						},
+						// Freshly created team: no existing members, pending invites, or child teams.
+						MockListTeamMembersBySlug: func(ctx context.Context, org, slug string, opts *github.TeamListTeamMembersOptions) ([]*github.User, *github.Response, error) {
+							return nil, fake.GenerateEmptyResponse(), nil
+						},
+						MockListPendingTeamInvitationsBySlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Invitation, *github.Response, error) {
+							return nil, fake.GenerateEmptyResponse(), nil
+						},
+						MockListChildTeamsByParentSlug: func(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
+							return nil, fake.GenerateEmptyResponse(), nil
+						},
+					},
+					Organizations: &fake.MockOrganizationsClient{
+						MockGetOrgMembership: func(ctx context.Context, user, org string) (*github.Membership, *github.Response, error) {
+							if !tc.active {
+								return nil, nil, fake.Generate404Response()
+							}
+							state := "active"
+							return &github.Membership{State: &state}, fake.GenerateEmptyResponse(), nil
+						},
+					},
+				},
+			}
+
+			cr := team()
+			cr.Spec.ForProvider.Members = tc.members
+			e := external{github: gh}
+			_, err := e.Create(context.Background(), cr)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ne.Create(...): -want error, +got error:\n%s\n", tc.reason, diff)
+			}
+			if addCalls != tc.want.addCalls {
+				t.Errorf("\n%s\nAddTeamMembershipBySlug calls = %d, want %d", tc.reason, addCalls, tc.want.addCalls)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Stop the team controller reconcile-looping on members it cannot remove — those inherited from child teams, and org admins whose maintainer role GitHub enforces.
- Skip team-membership writes for users who aren't org members yet, which previously triggered an unwanted org invitation as a side effect.
- Add a `TeamMembershipPartial` status condition that surfaces members the controller intentionally leaves alone.

## Problem

The team controller compared the declared members against the team's full membership rollup. That rollup includes members inherited from child teams and org admins, whom GitHub force-applies the `maintainer` role to. The controller treated those as drift and issued removals that GitHub silently no-ops, so the resource never reached `UpToDate` and re-issued the same calls on every poll.

Separately, declaring a user who is not yet an org member issued a team-membership PUT, which sends an org invitation as a side effect.

## What changes

- `internal/controller/team/team.go` — replace the blind member diff with per-member classification: members inherited from a child team are left in place (a parent-level removal is a no-op); an org admin whose maintainer role is enforced is reported, not re-applied; users with a pending org or team invitation are treated as in-flight; users not yet org members are skipped (no PUT, no stray invite); genuine direct memberships are added, updated, or removed. `Create` reuses the same path. Add the `TeamMembershipPartial` condition listing skipped members and why. Pending-invitation lookups are skipped when every declared member is already on the team; member/response reads are nil-guarded.
- `internal/clients/{services,client,fake}.go` — add `Teams.ListPendingTeamInvitationsBySlug` and `Teams.ListChildTeamsByParentSlug` wrappers, rate-limit-tracked like the rest.
- `internal/controller/team/team_test.go` — unit coverage for the classification, the condition, and the non-member skip.
- `examples/organizations/team.yaml` — clarify the org-admin maintainer note.

## Test plan

- [x] Unit tests cover member classification, the partial condition, and the non-member skip.
- [x] End-to-end on a test GitHub org: inherited and org-enforced members no longer loop, no stray org invitations, pending invitations tolerated, multi-level (grandchild) inheritance and cross-controller membership handoff verified.
- [x] `make reviewable` clean.

## Notes

- Net effect on the team controller: the repeated no-op removals are eliminated; in exchange, each team's reconcile lists its direct children's members to detect inheritance. Reads replace repeated no-op writes, so overall call volume is comparable and stays well within rate limits.
- Converged teams don't pay for pending-invitation lookups — those run only when a declared member isn't yet on the team.
- No new CRD or API; the only API-surface addition is the `TeamMembershipPartial` status condition.
